### PR TITLE
Remove RuleEngine class

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ checkAccess(rules, actor, Operation.Edit, { resource: "invoice", status: Invoice
 
 ### 4. Nested rules
 
-Rules can be nested to express complex permission trees. `RuleEngine` traverses these `rules` arrays recursively.
+Rules can be nested to express complex permission trees. `checkAccess` traverses these `rules` arrays recursively.
 
 ```ts
 import { Rule } from "@soudasuwa/permissions";
@@ -154,12 +154,12 @@ export const nestedRules: readonly Rule<Role, Operation, Resource>[] = [
 ];
 ```
 
-### 5. Reusing a `RuleEngine` instance
+### 5. Repeated checks
 
-For repeated checks you can create a `RuleEngine` once and reuse it.
+`checkAccess` can be called multiple times with the same rule set.
 
 ```ts
-import { RuleEngine, type Rule } from "@soudasuwa/permissions";
+import { checkAccess, type Rule } from "@soudasuwa/permissions";
 
 enum Role {
   Admin = "admin",
@@ -175,10 +175,8 @@ const rules: readonly Rule<Role, Operation, Resource>[] = [
   { meta: { role: Role.Admin, operation: Operation.View, resource: "invoice" } },
 ];
 
-const engine = new RuleEngine(rules);
-
 const actor = { id: "42", role: Role.Admin };
 const ctx = { resource: "invoice" };
 
-engine.checkAccess(actor, Operation.View, ctx); // true
+checkAccess(rules, actor, Operation.View, ctx); // true
 ```

--- a/dist/engine.d.ts
+++ b/dist/engine.d.ts
@@ -55,25 +55,12 @@ export declare const matchesMeta: <R extends StringLiteral = StringLiteral, O ex
  */
 export declare const matchesRule: <R extends StringLiteral = StringLiteral, O extends StringLiteral = StringLiteral, Res extends StringLiteral = StringLiteral>(rule: Rule<R, O, Res>, actor: Actor<R>, action: O, context: Context<Res>) => boolean;
 /**
- * Evaluates rules in an object-oriented manner to keep logic
- * encapsulated and reusable. A single RuleEngine instance can
- * be reused for repeated checks without re-parsing the rule set.
+ * Recursively evaluate a rules array, returning true as soon as a matching
+ * rule chain is found.
  */
-export declare class RuleEngine<R extends StringLiteral = StringLiteral, O extends StringLiteral = StringLiteral, Res extends StringLiteral = StringLiteral> {
-    private readonly rules;
-    constructor(rules: readonly Rule<R, O, Res>[]);
-    /**
-     * Determine if the given actor can perform an action on the context.
-     */
-    checkAccess(actor: Actor<R>, action: O, context: Context<Res>): boolean;
-    /**
-     * Evaluate a rules array recursively, returning true as soon
-     * as a matching rule chain is found.
-     */
-    private evaluateRules;
-}
+export declare const evaluateRules: <R extends StringLiteral = StringLiteral, O extends StringLiteral = StringLiteral, Res extends StringLiteral = StringLiteral>(rules: readonly Rule<R, O, Res>[], actor: Actor<R>, action: O, context: Context<Res>) => boolean;
 /**
- * Convenience function for one-off access checks. It creates a
- * temporary RuleEngine instance under the hood.
+ * Convenience function for one-off access checks. It evaluates the rule set
+ * directly without the need for a `RuleEngine` instance.
  */
 export declare const checkAccess: <R extends StringLiteral = StringLiteral, O extends StringLiteral = StringLiteral, Res extends StringLiteral = StringLiteral>(rules: readonly Rule<R, O, Res>[], actor: Actor<R>, action: O, context: Context<Res>) => boolean;

--- a/dist/engine.js
+++ b/dist/engine.js
@@ -51,32 +51,13 @@ export const matchesRule = (rule, actor, action, context) => {
         Object.entries(rule.match).every(([field, cond]) => matchCondition(context?.[field], cond, actor)));
 };
 /**
- * Evaluates rules in an object-oriented manner to keep logic
- * encapsulated and reusable. A single RuleEngine instance can
- * be reused for repeated checks without re-parsing the rule set.
+ * Recursively evaluate a rules array, returning true as soon as a matching
+ * rule chain is found.
  */
-export class RuleEngine {
-    rules;
-    constructor(rules) {
-        this.rules = rules;
-    }
-    /**
-     * Determine if the given actor can perform an action on the context.
-     */
-    checkAccess(actor, action, context) {
-        return this.evaluateRules(this.rules, actor, action, context);
-    }
-    /**
-     * Evaluate a rules array recursively, returning true as soon
-     * as a matching rule chain is found.
-     */
-    evaluateRules(rules, actor, action, context) {
-        return rules.some((r) => matchesRule(r, actor, action, context) &&
-            (r.rules ? this.evaluateRules(r.rules, actor, action, context) : true));
-    }
-}
+export const evaluateRules = (rules, actor, action, context) => rules.some((r) => matchesRule(r, actor, action, context) &&
+    (r.rules ? evaluateRules(r.rules, actor, action, context) : true));
 /**
- * Convenience function for one-off access checks. It creates a
- * temporary RuleEngine instance under the hood.
+ * Convenience function for one-off access checks. It evaluates the rule set
+ * directly without the need for a `RuleEngine` instance.
  */
-export const checkAccess = (rules, actor, action, context) => new RuleEngine(rules).checkAccess(actor, action, context);
+export const checkAccess = (rules, actor, action, context) => evaluateRules(rules, actor, action, context);

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,1 +1,1 @@
-export { RuleEngine, checkAccess, type Actor, type Context, type Rule, matchCondition, } from "./engine";
+export { checkAccess, type Actor, type Context, type Rule, matchCondition, } from "./engine";

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,1 +1,1 @@
-export { RuleEngine, checkAccess, matchCondition, } from "./engine";
+export { checkAccess, matchCondition, } from "./engine";

--- a/examples/invoice/invoice.test.ts
+++ b/examples/invoice/invoice.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test";
 
-import { checkAccess, RuleEngine } from "../../src/index";
+import { checkAccess } from "../../src/index";
 import { rules, Operation } from "./rules";
 
 const mock = {
@@ -269,18 +269,6 @@ describe("Invoice access control", () => {
 				},
 			);
 			expect(result).toBe(false);
-		});
-	});
-
-	describe("RuleEngine class", () => {
-		it("Delegates access checks correctly", () => {
-			const engine = new RuleEngine(rules);
-			const result = engine.checkAccess(
-				mock.actor.role("admin"),
-				Operation.View,
-				mock.invoice.status("Complete"),
-			);
-			expect(result).toBe(true);
 		});
 	});
 });

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -142,45 +142,28 @@ export const matchesRule = <
 };
 
 /**
- * Evaluates rules in an object-oriented manner to keep logic
- * encapsulated and reusable. A single RuleEngine instance can
- * be reused for repeated checks without re-parsing the rule set.
+ * Recursively evaluate a rules array, returning true as soon as a matching
+ * rule chain is found.
  */
-export class RuleEngine<
+export const evaluateRules = <
 	R extends StringLiteral = StringLiteral,
 	O extends StringLiteral = StringLiteral,
 	Res extends StringLiteral = StringLiteral,
-> {
-	constructor(private readonly rules: readonly Rule<R, O, Res>[]) {}
-
-	/**
-	 * Determine if the given actor can perform an action on the context.
-	 */
-	checkAccess(actor: Actor<R>, action: O, context: Context<Res>): boolean {
-		return this.evaluateRules(this.rules, actor, action, context);
-	}
-
-	/**
-	 * Evaluate a rules array recursively, returning true as soon
-	 * as a matching rule chain is found.
-	 */
-	private evaluateRules(
-		rules: readonly Rule<R, O, Res>[],
-		actor: Actor<R>,
-		action: O,
-		context: Context<Res>,
-	): boolean {
-		return rules.some(
-			(r) =>
-				matchesRule(r, actor, action, context) &&
-				(r.rules ? this.evaluateRules(r.rules, actor, action, context) : true),
-		);
-	}
-}
+>(
+	rules: readonly Rule<R, O, Res>[],
+	actor: Actor<R>,
+	action: O,
+	context: Context<Res>,
+): boolean =>
+	rules.some(
+		(r) =>
+			matchesRule(r, actor, action, context) &&
+			(r.rules ? evaluateRules(r.rules, actor, action, context) : true),
+	);
 
 /**
- * Convenience function for one-off access checks. It creates a
- * temporary RuleEngine instance under the hood.
+ * Convenience function for one-off access checks. It evaluates the rule set
+ * directly without the need for a `RuleEngine` instance.
  */
 export const checkAccess = <
 	R extends StringLiteral = StringLiteral,
@@ -191,5 +174,4 @@ export const checkAccess = <
 	actor: Actor<R>,
 	action: O,
 	context: Context<Res>,
-): boolean =>
-	new RuleEngine<R, O, Res>(rules).checkAccess(actor, action, context);
+): boolean => evaluateRules(rules, actor, action, context);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 export {
-	RuleEngine,
 	checkAccess,
 	type Actor,
 	type Context,

--- a/src/test.test.ts
+++ b/src/test.test.ts
@@ -3,7 +3,6 @@ import {
 	matchCondition,
 	matchesMeta,
 	matchesRule,
-	RuleEngine,
 	checkAccess,
 	type Actor,
 	type Context,
@@ -192,13 +191,6 @@ describe("checkAccess simple", () => {
 	it("rejects mismatched meta", () => {
 		expect(checkAccess(rules, actor, Operation.Edit, ctx)).toBe(false);
 	});
-
-	it("matches RuleEngine results", () => {
-		const engine = new RuleEngine(rules);
-		expect(engine.checkAccess(actor, Operation.View, ctx)).toBe(
-			checkAccess(rules, actor, Operation.View, ctx),
-		);
-	});
 });
 
 // ---------------- Integration tests ----------------
@@ -280,27 +272,31 @@ describe("advanced nested rules", () => {
 			],
 		},
 	];
-	const engine = new RuleEngine(advancedRules);
-
 	it("admin can view invoice", () => {
 		const ctx = { resource: "invoice" } as const;
-		expect(engine.checkAccess(dummyActor, Operation.View, ctx)).toBe(true);
+		expect(checkAccess(advancedRules, dummyActor, Operation.View, ctx)).toBe(
+			true,
+		);
 	});
 
 	it("admin can edit draft invoice", () => {
 		const ctx = { resource: "invoice", status: Status.Draft } as const;
-		expect(engine.checkAccess(dummyActor, Operation.Edit, ctx)).toBe(true);
+		expect(checkAccess(advancedRules, dummyActor, Operation.Edit, ctx)).toBe(
+			true,
+		);
 	});
 
 	it("admin cannot edit pending invoice", () => {
 		const ctx = { resource: "invoice", status: Status.Pending } as const;
-		expect(engine.checkAccess(dummyActor, Operation.Edit, ctx)).toBe(false);
+		expect(checkAccess(advancedRules, dummyActor, Operation.Edit, ctx)).toBe(
+			false,
+		);
 	});
 
 	it("fails when role mismatch", () => {
 		const user: Actor<Role> = { id: "2", role: Role.User };
 		const ctx = { resource: "invoice" } as const;
-		expect(engine.checkAccess(user, Operation.View, ctx)).toBe(false);
+		expect(checkAccess(advancedRules, user, Operation.View, ctx)).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## Summary
- remove `RuleEngine` class and implement `evaluateRules` helper
- rely on `checkAccess` everywhere
- update tests and docs for `checkAccess`

## Testing
- `bun run lint`
- `bun run format`
- `bun run build`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68507c574dc0832e83feca53741a9f83