### PR TITLE
Add unbiased meta matcher interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,25 @@ enum InvoiceStatus {
 
 type Resource = "invoice";
 
-const rules: readonly Rule<Role, Operation, Resource>[] = [
+interface Meta {
+  role?: Role | readonly Role[];
+  operation?: Operation;
+  resource?: Resource;
+}
+
+const matcher: MetaMatcher<Meta> = (meta, actor, action, ctx) => {
+  if (!meta) return true;
+  const { role, operation, resource } = meta;
+  if (role) {
+    const roles = Array.isArray(role) ? role : [role];
+    if (!roles.includes((actor as { role?: Role }).role ?? Role.User)) return false;
+  }
+  if (resource && resource !== (ctx as { resource?: Resource }).resource) return false;
+  if (operation && operation !== action) return false;
+  return true;
+};
+
+const rules: readonly Rule<Meta>[] = [
   {
     meta: { role: Role.User, operation: Operation.Pay, resource: "invoice" },
     match: { status: InvoiceStatus.Pending },
@@ -59,7 +77,7 @@ const context = {
   status: InvoiceStatus.Pending,
 };
 
-const allowed = checkAccess(rules, actor, Operation.Pay, context);
+const allowed = checkAccess(rules, actor, Operation.Pay, context, matcher);
 console.log(allowed); // true
 ```
 
@@ -90,7 +108,7 @@ const rules: readonly Rule<Role, Operation, Resource>[] = [
 const actor = { id: "abc", role: Role.User };
 const context = { resource: "invoice", userId: "abc" };
 
-checkAccess(rules, actor, Operation.View, context); // true
+checkAccess(rules, actor, Operation.View, context, matcher); // true
 ```
 
 ### 3. `in` and `not` conditions
@@ -128,8 +146,8 @@ const rules: readonly Rule<Role, Operation, Resource>[] = [
 ];
 
 const actor = { id: "1", role: Role.Admin };
-checkAccess(rules, actor, Operation.Edit, { resource: "invoice", status: InvoiceStatus.Draft }); // true
-checkAccess(rules, actor, Operation.Edit, { resource: "invoice", status: InvoiceStatus.Complete }); // false
+checkAccess(rules, actor, Operation.Edit, { resource: "invoice", status: InvoiceStatus.Draft }, matcher); // true
+checkAccess(rules, actor, Operation.Edit, { resource: "invoice", status: InvoiceStatus.Complete }, matcher); // false
 ```
 
 ### 4. Nested rules
@@ -171,12 +189,12 @@ enum Operation {
 
 type Resource = "invoice";
 
-const rules: readonly Rule<Role, Operation, Resource>[] = [
+const rules: readonly Rule<Meta>[] = [
   { meta: { role: Role.Admin, operation: Operation.View, resource: "invoice" } },
 ];
 
 const actor = { id: "42", role: Role.Admin };
 const ctx = { resource: "invoice" };
 
-checkAccess(rules, actor, Operation.View, ctx); // true
+checkAccess(rules, actor, Operation.View, ctx, matcher); // true
 ```

--- a/dist/engine.d.ts
+++ b/dist/engine.d.ts
@@ -1,11 +1,8 @@
 export type StringLiteral = string;
-export interface Actor<R extends StringLiteral = StringLiteral> {
-    readonly role: R;
-    readonly id: string;
+export interface Actor {
     readonly [key: string]: unknown;
 }
-export interface Context<Res extends StringLiteral = StringLiteral> {
-    readonly resource: Res;
+export interface Context {
     readonly [key: string]: unknown;
 }
 export interface ReferenceCondition {
@@ -23,15 +20,10 @@ export type ConditionObject = {
     readonly [key: string]: Condition;
 };
 export type Condition = string | number | boolean | NotCondition | InCondition | ReferenceCondition | ConditionObject;
-export interface RuleMeta<R extends StringLiteral = StringLiteral, O extends StringLiteral = StringLiteral, Res extends StringLiteral = StringLiteral> {
-    readonly role?: R | readonly R[];
-    readonly resource?: Res;
-    readonly operation?: O;
-}
-export interface Rule<R extends StringLiteral = StringLiteral, O extends StringLiteral = StringLiteral, Res extends StringLiteral = StringLiteral> {
-    readonly meta?: RuleMeta<R, O, Res>;
+export interface Rule<M extends Record<string, unknown> = Record<string, unknown>> {
+    readonly meta?: M;
     readonly match?: Readonly<Record<string, Condition>>;
-    readonly rules?: readonly Rule<R, O, Res>[];
+    readonly rules?: readonly Rule<M>[];
 }
 /**
  * Compare a context value against the provided condition.
@@ -40,27 +32,22 @@ export interface Rule<R extends StringLiteral = StringLiteral, O extends StringL
  * supports negation, inclusion lists and references to
  * the actor performing the check.
  */
-export declare const matchCondition: <R extends StringLiteral>(value: unknown, condition: Condition, actor: Actor<R>) => boolean;
-/**
- * Determine whether a rule's meta information matches the
- * provided actor, action and context. Role arrays are
- * supported for cases where multiple roles share a rule.
- */
-export declare const matchesMeta: <R extends StringLiteral = StringLiteral, O extends StringLiteral = StringLiteral, Res extends StringLiteral = StringLiteral>(meta: RuleMeta<R, O, Res> | undefined, actor: Actor<R>, action: O, context: Context<Res>) => boolean;
+export declare const matchCondition: (value: unknown, condition: Condition, actor: Actor) => boolean;
 /**
  * Validate that a rule applies to the given actor and context.
  *
  * Both the meta information and the optional match block must
  * succeed in order for the rule to match.
  */
-export declare const matchesRule: <R extends StringLiteral = StringLiteral, O extends StringLiteral = StringLiteral, Res extends StringLiteral = StringLiteral>(rule: Rule<R, O, Res>, actor: Actor<R>, action: O, context: Context<Res>) => boolean;
+export type MetaMatcher<M extends Record<string, unknown> = Record<string, unknown>, A extends Actor = Actor, Act = string, C extends Context = Context> = (meta: M | undefined, actor: A, action: Act, context: C) => boolean;
+export declare const matchesRule: <M extends Record<string, unknown> = Record<string, unknown>, A extends Actor = Actor, Act = string, C extends Context = Context>(rule: Rule<M>, actor: A, action: Act, context: C, matchMeta: MetaMatcher<M, A, Act, C>) => boolean;
 /**
  * Recursively evaluate a rules array, returning true as soon as a matching
  * rule chain is found.
  */
-export declare const evaluateRules: <R extends StringLiteral = StringLiteral, O extends StringLiteral = StringLiteral, Res extends StringLiteral = StringLiteral>(rules: readonly Rule<R, O, Res>[], actor: Actor<R>, action: O, context: Context<Res>) => boolean;
+export declare const evaluateRules: <M extends Record<string, unknown> = Record<string, unknown>, A extends Actor = Actor, Act = string, C extends Context = Context>(rules: readonly Rule<M>[], actor: A, action: Act, context: C, matchMeta: MetaMatcher<M, A, Act, C>) => boolean;
 /**
  * Convenience function for one-off access checks. It evaluates the rule set
  * directly without the need for a `RuleEngine` instance.
  */
-export declare const checkAccess: <R extends StringLiteral = StringLiteral, O extends StringLiteral = StringLiteral, Res extends StringLiteral = StringLiteral>(rules: readonly Rule<R, O, Res>[], actor: Actor<R>, action: O, context: Context<Res>) => boolean;
+export declare const checkAccess: <M extends Record<string, unknown> = Record<string, unknown>, A extends Actor = Actor, Act = string, C extends Context = Context>(rules: readonly Rule<M>[], actor: A, action: Act, context: C, matchMeta: MetaMatcher<M, A, Act, C>) => boolean;

--- a/dist/engine.js
+++ b/dist/engine.js
@@ -18,34 +18,8 @@ export const matchCondition = (value, condition, actor) => {
     }
     return value === condition;
 };
-/**
- * Determine whether a rule's meta information matches the
- * provided actor, action and context. Role arrays are
- * supported for cases where multiple roles share a rule.
- */
-export const matchesMeta = (meta, actor, action, context) => {
-    if (!meta)
-        return true;
-    const { role, resource, operation } = meta;
-    if (role) {
-        const roles = Array.isArray(role) ? role : [role];
-        if (!roles.includes(actor.role))
-            return false;
-    }
-    if (resource && resource !== context.resource)
-        return false;
-    if (operation && operation !== action)
-        return false;
-    return true;
-};
-/**
- * Validate that a rule applies to the given actor and context.
- *
- * Both the meta information and the optional match block must
- * succeed in order for the rule to match.
- */
-export const matchesRule = (rule, actor, action, context) => {
-    if (!matchesMeta(rule.meta, actor, action, context))
+export const matchesRule = (rule, actor, action, context, matchMeta) => {
+    if (!matchMeta(rule.meta, actor, action, context))
         return false;
     return (!rule.match ||
         Object.entries(rule.match).every(([field, cond]) => matchCondition(context?.[field], cond, actor)));
@@ -54,10 +28,12 @@ export const matchesRule = (rule, actor, action, context) => {
  * Recursively evaluate a rules array, returning true as soon as a matching
  * rule chain is found.
  */
-export const evaluateRules = (rules, actor, action, context) => rules.some((r) => matchesRule(r, actor, action, context) &&
-    (r.rules ? evaluateRules(r.rules, actor, action, context) : true));
+export const evaluateRules = (rules, actor, action, context, matchMeta) => rules.some((r) => matchesRule(r, actor, action, context, matchMeta) &&
+    (r.rules
+        ? evaluateRules(r.rules, actor, action, context, matchMeta)
+        : true));
 /**
  * Convenience function for one-off access checks. It evaluates the rule set
  * directly without the need for a `RuleEngine` instance.
  */
-export const checkAccess = (rules, actor, action, context) => evaluateRules(rules, actor, action, context);
+export const checkAccess = (rules, actor, action, context, matchMeta) => evaluateRules(rules, actor, action, context, matchMeta);

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,1 +1,1 @@
-export { checkAccess, type Actor, type Context, type Rule, matchCondition, } from "./engine";
+export { checkAccess, type Actor, type Context, type Rule, type MetaMatcher, matchesRule, matchCondition, } from "./engine";

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,1 +1,1 @@
-export { checkAccess, matchCondition, } from "./engine";
+export { checkAccess, matchesRule, matchCondition, } from "./engine";

--- a/examples/invoice/invoice.test.ts
+++ b/examples/invoice/invoice.test.ts
@@ -1,7 +1,26 @@
 import { describe, it, expect } from "bun:test";
 
-import { checkAccess } from "../../src/index";
+import { checkAccess, type MetaMatcher } from "../../src/index";
 import { rules, Operation } from "./rules";
+
+interface StdMeta {
+	role?: string | readonly string[];
+	operation?: string;
+	resource?: string;
+}
+
+const matcher: MetaMatcher<StdMeta> = (meta, actor, action, context) => {
+	if (!meta) return true;
+	const { role, operation, resource } = meta;
+	if (role) {
+		const roles = Array.isArray(role) ? role : [role];
+		if (!roles.includes((actor as { role?: string }).role ?? "")) return false;
+	}
+	if (operation && operation !== action) return false;
+	if (resource && resource !== (context as { resource?: string }).resource)
+		return false;
+	return true;
+};
 
 const mock = {
 	invoice: {
@@ -34,6 +53,7 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Generating"),
 					payload: { status: "Draft" },
 				},
+				matcher,
 			);
 			expect(result).toBe(true);
 		});
@@ -47,6 +67,7 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Draft"),
 					payload: { status: "Pending" },
 				},
+				matcher,
 			);
 			expect(result).toBe(false);
 		});
@@ -57,6 +78,7 @@ describe("Invoice access control", () => {
 				mock.actor.role("module"),
 				Operation.View,
 				mock.invoice.status("Generating"),
+				matcher,
 			);
 			expect(result).toBe(false);
 		});
@@ -72,6 +94,7 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Draft"),
 					payload: { status: "Pending" },
 				},
+				matcher,
 			);
 			expect(result).toBe(true);
 		});
@@ -85,6 +108,7 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Pending"),
 					payload: { status: "Draft" },
 				},
+				matcher,
 			);
 			expect(result).toBe(true);
 		});
@@ -98,6 +122,7 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Generating"),
 					payload: { status: "Draft" },
 				},
+				matcher,
 			);
 			expect(result).toBe(false);
 		});
@@ -108,6 +133,7 @@ describe("Invoice access control", () => {
 				mock.actor.role("admin"),
 				Operation.View,
 				mock.invoice.status("Complete"),
+				matcher,
 			);
 			expect(result).toBe(true);
 		});
@@ -121,6 +147,7 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Complete"),
 					payload: { status: "Pending" },
 				},
+				matcher,
 			);
 			expect(result).toBe(false);
 		});
@@ -133,6 +160,7 @@ describe("Invoice access control", () => {
 				mock.actor.role("user"),
 				Operation.View,
 				mock.invoice.status("Pending"),
+				matcher,
 			);
 			expect(result).toBe(true);
 		});
@@ -143,6 +171,7 @@ describe("Invoice access control", () => {
 				mock.actor.role("user"),
 				Operation.Pay,
 				mock.invoice.status("Pending"),
+				matcher,
 			);
 			expect(result).toBe(true);
 		});
@@ -153,6 +182,7 @@ describe("Invoice access control", () => {
 				mock.actor.role("user"),
 				Operation.View,
 				mock.invoice.status("Draft"),
+				matcher,
 			);
 			expect(result).toBe(false);
 		});
@@ -163,6 +193,7 @@ describe("Invoice access control", () => {
 				mock.actor.role("user"),
 				Operation.View,
 				mock.invoice.status("Generating"),
+				matcher,
 			);
 			expect(result).toBe(false);
 		});
@@ -173,6 +204,7 @@ describe("Invoice access control", () => {
 				mock.actor.role("user"),
 				Operation.View,
 				mock.invoice.status("Complete"),
+				matcher,
 			);
 			expect(result).toBe(true);
 		});
@@ -183,6 +215,7 @@ describe("Invoice access control", () => {
 				mock.actor.role("user"),
 				Operation.Pay,
 				mock.invoice.status("Complete"),
+				matcher,
 			);
 			expect(result).toBe(false);
 		});
@@ -196,6 +229,7 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Pending"),
 					userId: "different-user",
 				},
+				matcher,
 			);
 			expect(result).toBe(false);
 		});
@@ -211,6 +245,7 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Generating"),
 					payload: { status: "Generating" },
 				},
+				matcher,
 			);
 			expect(result).toBe(true);
 		});
@@ -224,6 +259,7 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Draft"),
 					payload: { status: "Draft" },
 				},
+				matcher,
 			);
 			expect(result).toBe(false);
 		});
@@ -239,6 +275,7 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Draft"),
 					payload: { status: "Draft" },
 				},
+				matcher,
 			);
 			expect(result).toBe(true);
 		});
@@ -252,6 +289,7 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Generating"),
 					payload: { status: "Generating" },
 				},
+				matcher,
 			);
 			expect(result).toBe(false);
 		});
@@ -267,6 +305,7 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Pending"),
 					payload: { status: "Pending" },
 				},
+				matcher,
 			);
 			expect(result).toBe(false);
 		});

--- a/examples/invoice/rules.ts
+++ b/examples/invoice/rules.ts
@@ -22,7 +22,13 @@ export type Resource = "invoice";
 
 import type { Rule } from "../../src/engine";
 
-export const rules: readonly Rule<Role, Operation, Resource>[] = [
+interface StdMeta {
+	role?: Role | readonly Role[];
+	operation?: Operation;
+	resource?: Resource;
+}
+
+export const rules: readonly Rule<StdMeta>[] = [
 	{
 		meta: { resource: "invoice" },
 		rules: [

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,13 +1,10 @@
 export type StringLiteral = string;
 
-export interface Actor<R extends StringLiteral = StringLiteral> {
-	readonly role: R;
-	readonly id: string;
+export interface Actor {
 	readonly [key: string]: unknown;
 }
 
-export interface Context<Res extends StringLiteral = StringLiteral> {
-	readonly resource: Res;
+export interface Context {
 	readonly [key: string]: unknown;
 }
 
@@ -36,24 +33,12 @@ export type Condition =
 	| ReferenceCondition
 	| ConditionObject;
 
-export interface RuleMeta<
-	R extends StringLiteral = StringLiteral,
-	O extends StringLiteral = StringLiteral,
-	Res extends StringLiteral = StringLiteral,
-> {
-	readonly role?: R | readonly R[];
-	readonly resource?: Res;
-	readonly operation?: O;
-}
-
 export interface Rule<
-	R extends StringLiteral = StringLiteral,
-	O extends StringLiteral = StringLiteral,
-	Res extends StringLiteral = StringLiteral,
+	M extends Record<string, unknown> = Record<string, unknown>,
 > {
-	readonly meta?: RuleMeta<R, O, Res>;
+	readonly meta?: M;
 	readonly match?: Readonly<Record<string, Condition>>;
-	readonly rules?: readonly Rule<R, O, Res>[];
+	readonly rules?: readonly Rule<M>[];
 }
 
 /**
@@ -63,10 +48,10 @@ export interface Rule<
  * supports negation, inclusion lists and references to
  * the actor performing the check.
  */
-export const matchCondition = <R extends StringLiteral>(
+export const matchCondition = (
 	value: unknown,
 	condition: Condition,
-	actor: Actor<R>,
+	actor: Actor,
 ): boolean => {
 	if (condition && typeof condition === "object" && !Array.isArray(condition)) {
 		if ("not" in condition)
@@ -90,53 +75,39 @@ export const matchCondition = <R extends StringLiteral>(
 };
 
 /**
- * Determine whether a rule's meta information matches the
- * provided actor, action and context. Role arrays are
- * supported for cases where multiple roles share a rule.
- */
-export const matchesMeta = <
-	R extends StringLiteral = StringLiteral,
-	O extends StringLiteral = StringLiteral,
-	Res extends StringLiteral = StringLiteral,
->(
-	meta: RuleMeta<R, O, Res> | undefined,
-	actor: Actor<R>,
-	action: O,
-	context: Context<Res>,
-): boolean => {
-	if (!meta) return true;
-	const { role, resource, operation } = meta;
-
-	if (role) {
-		const roles = Array.isArray(role) ? role : [role];
-		if (!roles.includes(actor.role)) return false;
-	}
-	if (resource && resource !== context.resource) return false;
-	if (operation && operation !== action) return false;
-	return true;
-};
-
-/**
  * Validate that a rule applies to the given actor and context.
  *
  * Both the meta information and the optional match block must
  * succeed in order for the rule to match.
  */
+export type MetaMatcher<
+	M extends Record<string, unknown> = Record<string, unknown>,
+	A extends Actor = Actor,
+	Act = string,
+	C extends Context = Context,
+> = (meta: M | undefined, actor: A, action: Act, context: C) => boolean;
+
 export const matchesRule = <
-	R extends StringLiteral = StringLiteral,
-	O extends StringLiteral = StringLiteral,
-	Res extends StringLiteral = StringLiteral,
+	M extends Record<string, unknown> = Record<string, unknown>,
+	A extends Actor = Actor,
+	Act = string,
+	C extends Context = Context,
 >(
-	rule: Rule<R, O, Res>,
-	actor: Actor<R>,
-	action: O,
-	context: Context<Res>,
+	rule: Rule<M>,
+	actor: A,
+	action: Act,
+	context: C,
+	matchMeta: MetaMatcher<M, A, Act, C>,
 ): boolean => {
-	if (!matchesMeta(rule.meta, actor, action, context)) return false;
+	if (!matchMeta(rule.meta, actor, action, context)) return false;
 	return (
 		!rule.match ||
 		Object.entries(rule.match).every(([field, cond]) =>
-			matchCondition(context?.[field], cond as Condition, actor),
+			matchCondition(
+				(context as Record<string, unknown>)?.[field],
+				cond as Condition,
+				actor,
+			),
 		)
 	);
 };
@@ -146,19 +117,23 @@ export const matchesRule = <
  * rule chain is found.
  */
 export const evaluateRules = <
-	R extends StringLiteral = StringLiteral,
-	O extends StringLiteral = StringLiteral,
-	Res extends StringLiteral = StringLiteral,
+	M extends Record<string, unknown> = Record<string, unknown>,
+	A extends Actor = Actor,
+	Act = string,
+	C extends Context = Context,
 >(
-	rules: readonly Rule<R, O, Res>[],
-	actor: Actor<R>,
-	action: O,
-	context: Context<Res>,
+	rules: readonly Rule<M>[],
+	actor: A,
+	action: Act,
+	context: C,
+	matchMeta: MetaMatcher<M, A, Act, C>,
 ): boolean =>
 	rules.some(
 		(r) =>
-			matchesRule(r, actor, action, context) &&
-			(r.rules ? evaluateRules(r.rules, actor, action, context) : true),
+			matchesRule(r, actor, action, context, matchMeta) &&
+			(r.rules
+				? evaluateRules(r.rules, actor, action, context, matchMeta)
+				: true),
 	);
 
 /**
@@ -166,12 +141,14 @@ export const evaluateRules = <
  * directly without the need for a `RuleEngine` instance.
  */
 export const checkAccess = <
-	R extends StringLiteral = StringLiteral,
-	O extends StringLiteral = StringLiteral,
-	Res extends StringLiteral = StringLiteral,
+	M extends Record<string, unknown> = Record<string, unknown>,
+	A extends Actor = Actor,
+	Act = string,
+	C extends Context = Context,
 >(
-	rules: readonly Rule<R, O, Res>[],
-	actor: Actor<R>,
-	action: O,
-	context: Context<Res>,
-): boolean => evaluateRules(rules, actor, action, context);
+	rules: readonly Rule<M>[],
+	actor: A,
+	action: Act,
+	context: C,
+	matchMeta: MetaMatcher<M, A, Act, C>,
+): boolean => evaluateRules(rules, actor, action, context, matchMeta);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,7 @@ export {
 	type Actor,
 	type Context,
 	type Rule,
+	type MetaMatcher,
+	matchesRule,
 	matchCondition,
 } from "./engine";

--- a/src/test.test.ts
+++ b/src/test.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from "bun:test";
 import {
 	matchCondition,
-	matchesMeta,
 	matchesRule,
 	checkAccess,
 	type Actor,
 	type Context,
 	type Rule,
+	type MetaMatcher,
 } from "./engine";
 
 // Shared enums for the invoice scenarios
@@ -32,9 +32,32 @@ enum Status {
 
 type Resource = "invoice";
 
-const dummyActor: Actor<Role> = { id: "1", role: Role.Admin };
+const dummyActor: Actor = { id: "1", role: Role.Admin };
 
-const complexRules: readonly Rule<Role, Operation, Resource>[] = [
+interface StdMeta {
+	role?: Role | readonly Role[];
+	operation?: Operation;
+	resource?: Resource;
+}
+
+const matcher: MetaMatcher<StdMeta, Actor, Operation, Context> = (
+	meta,
+	actor,
+	action,
+	context,
+) => {
+	if (!meta) return true;
+	const { role, operation, resource } = meta;
+	if (role) {
+		const roles = Array.isArray(role) ? role : [role];
+		if (!roles.includes(actor.role)) return false;
+	}
+	if (resource && resource !== context.resource) return false;
+	if (operation && operation !== action) return false;
+	return true;
+};
+
+const complexRules: readonly Rule<StdMeta>[] = [
 	{
 		meta: { resource: "invoice" },
 		rules: [
@@ -112,12 +135,12 @@ describe("matchCondition basic", () => {
 	});
 });
 
-describe("matchesMeta", () => {
-	const ctx: Context<Resource> = { resource: "invoice" };
-	const actor: Actor<Role> = { id: "1", role: Role.Admin };
+describe("meta matcher", () => {
+	const ctx: Context = { resource: "invoice" };
+	const actor: Actor = { id: "1", role: Role.Admin };
 
 	it("accepts undefined", () => {
-		expect(matchesMeta(undefined, actor, Operation.View, ctx)).toBe(true);
+		expect(matcher(undefined, actor, Operation.View, ctx)).toBe(true);
 	});
 
 	it("matches role arrays", () => {
@@ -126,53 +149,59 @@ describe("matchesMeta", () => {
 			operation: Operation.View,
 			resource: "invoice",
 		} as const;
-		expect(matchesMeta(meta, actor, Operation.View, ctx)).toBe(true);
+		expect(matcher(meta, actor, Operation.View, ctx)).toBe(true);
 	});
 
 	it("rejects wrong role", () => {
 		const meta = { role: Role.User } as const;
-		expect(matchesMeta(meta, actor, Operation.View, ctx)).toBe(false);
+		expect(matcher(meta, actor, Operation.View, ctx)).toBe(false);
 	});
 
 	it("rejects wrong resource", () => {
 		const meta = { resource: "other" as Resource };
-		expect(matchesMeta(meta, actor, Operation.View, ctx)).toBe(false);
+		expect(matcher(meta, actor, Operation.View, ctx)).toBe(false);
 	});
 
 	it("rejects wrong operation", () => {
 		const meta = { operation: Operation.Edit };
-		expect(matchesMeta(meta, actor, Operation.View, ctx)).toBe(false);
+		expect(matcher(meta, actor, Operation.View, ctx)).toBe(false);
 	});
 });
 
 describe("matchesRule", () => {
-	const actor: Actor<Role> = { id: "1", role: Role.Admin };
+	const actor: Actor = { id: "1", role: Role.Admin };
 	const ctx = { resource: "invoice", status: Status.Pending } as const;
-	const rule: Rule<Role, Operation, Resource> = {
+	const rule: Rule<StdMeta> = {
 		meta: { role: Role.Admin, operation: Operation.View, resource: "invoice" },
 		match: { status: Status.Pending },
 	};
 
 	it("returns true when meta and match pass", () => {
-		expect(matchesRule(rule, actor, Operation.View, ctx)).toBe(true);
+		expect(matchesRule(rule, actor, Operation.View, ctx, matcher)).toBe(true);
 	});
 
 	it("returns false when match fails", () => {
 		expect(
-			matchesRule(rule, actor, Operation.View, {
-				...ctx,
-				status: Status.Complete,
-			}),
+			matchesRule(
+				rule,
+				actor,
+				Operation.View,
+				{
+					...ctx,
+					status: Status.Complete,
+				},
+				matcher,
+			),
 		).toBe(false);
 	});
 
 	it("returns false when meta fails", () => {
-		expect(matchesRule(rule, actor, Operation.Edit, ctx)).toBe(false);
+		expect(matchesRule(rule, actor, Operation.Edit, ctx, matcher)).toBe(false);
 	});
 });
 
 describe("checkAccess simple", () => {
-	const rules: readonly Rule<Role, Operation, Resource>[] = [
+	const rules: readonly Rule<StdMeta>[] = [
 		{
 			meta: {
 				role: Role.Admin,
@@ -185,30 +214,34 @@ describe("checkAccess simple", () => {
 	const ctx = { resource: "invoice" } as const;
 
 	it("allows matching meta", () => {
-		expect(checkAccess(rules, actor, Operation.View, ctx)).toBe(true);
+		expect(checkAccess(rules, actor, Operation.View, ctx, matcher)).toBe(true);
 	});
 
 	it("rejects mismatched meta", () => {
-		expect(checkAccess(rules, actor, Operation.Edit, ctx)).toBe(false);
+		expect(checkAccess(rules, actor, Operation.Edit, ctx, matcher)).toBe(false);
 	});
 });
 
 // ---------------- Integration tests ----------------
 
 describe("invoice rules scenario", () => {
-	const admin: Actor<Role> = { id: "a", role: Role.Admin };
-	const moduleActor: Actor<Role> = { id: "m", role: Role.Module };
-	const user: Actor<Role> = { id: "u1", role: Role.User };
-	const otherUser: Actor<Role> = { id: "u2", role: Role.User };
+	const admin: Actor = { id: "a", role: Role.Admin };
+	const moduleActor: Actor = { id: "m", role: Role.Module };
+	const user: Actor = { id: "u1", role: Role.User };
+	const otherUser: Actor = { id: "u2", role: Role.User };
 
 	it("admin can edit draft invoice", () => {
 		const ctx = { resource: "invoice", status: Status.Draft } as const;
-		expect(checkAccess(complexRules, admin, Operation.Edit, ctx)).toBe(true);
+		expect(checkAccess(complexRules, admin, Operation.Edit, ctx, matcher)).toBe(
+			true,
+		);
 	});
 
 	it("admin cannot edit complete invoice", () => {
 		const ctx = { resource: "invoice", status: Status.Complete } as const;
-		expect(checkAccess(complexRules, admin, Operation.Edit, ctx)).toBe(false);
+		expect(checkAccess(complexRules, admin, Operation.Edit, ctx, matcher)).toBe(
+			false,
+		);
 	});
 
 	it("module can create generating invoice", () => {
@@ -217,9 +250,9 @@ describe("invoice rules scenario", () => {
 			status: Status.Generating,
 			payload: { status: Status.Generating },
 		} as const;
-		expect(checkAccess(complexRules, moduleActor, Operation.Create, ctx)).toBe(
-			true,
-		);
+		expect(
+			checkAccess(complexRules, moduleActor, Operation.Create, ctx, matcher),
+		).toBe(true);
 	});
 
 	it("module cannot create draft invoice", () => {
@@ -228,9 +261,9 @@ describe("invoice rules scenario", () => {
 			status: Status.Draft,
 			payload: { status: Status.Draft },
 		} as const;
-		expect(checkAccess(complexRules, moduleActor, Operation.Create, ctx)).toBe(
-			false,
-		);
+		expect(
+			checkAccess(complexRules, moduleActor, Operation.Create, ctx, matcher),
+		).toBe(false);
 	});
 
 	it("user can view own pending invoice", () => {
@@ -239,7 +272,9 @@ describe("invoice rules scenario", () => {
 			status: Status.Pending,
 			userId: "u1",
 		} as const;
-		expect(checkAccess(complexRules, user, Operation.View, ctx)).toBe(true);
+		expect(checkAccess(complexRules, user, Operation.View, ctx, matcher)).toBe(
+			true,
+		);
 	});
 
 	it("user cannot pay someone else's invoice", () => {
@@ -248,14 +283,14 @@ describe("invoice rules scenario", () => {
 			status: Status.Pending,
 			userId: "u1",
 		} as const;
-		expect(checkAccess(complexRules, otherUser, Operation.Pay, ctx)).toBe(
-			false,
-		);
+		expect(
+			checkAccess(complexRules, otherUser, Operation.Pay, ctx, matcher),
+		).toBe(false);
 	});
 });
 
 describe("advanced nested rules", () => {
-	const advancedRules: readonly Rule<Role, Operation, Resource>[] = [
+	const advancedRules: readonly Rule<StdMeta>[] = [
 		{
 			meta: { role: Role.Admin },
 			rules: [
@@ -274,29 +309,31 @@ describe("advanced nested rules", () => {
 	];
 	it("admin can view invoice", () => {
 		const ctx = { resource: "invoice" } as const;
-		expect(checkAccess(advancedRules, dummyActor, Operation.View, ctx)).toBe(
-			true,
-		);
+		expect(
+			checkAccess(advancedRules, dummyActor, Operation.View, ctx, matcher),
+		).toBe(true);
 	});
 
 	it("admin can edit draft invoice", () => {
 		const ctx = { resource: "invoice", status: Status.Draft } as const;
-		expect(checkAccess(advancedRules, dummyActor, Operation.Edit, ctx)).toBe(
-			true,
-		);
+		expect(
+			checkAccess(advancedRules, dummyActor, Operation.Edit, ctx, matcher),
+		).toBe(true);
 	});
 
 	it("admin cannot edit pending invoice", () => {
 		const ctx = { resource: "invoice", status: Status.Pending } as const;
-		expect(checkAccess(advancedRules, dummyActor, Operation.Edit, ctx)).toBe(
-			false,
-		);
+		expect(
+			checkAccess(advancedRules, dummyActor, Operation.Edit, ctx, matcher),
+		).toBe(false);
 	});
 
 	it("fails when role mismatch", () => {
-		const user: Actor<Role> = { id: "2", role: Role.User };
+		const user: Actor = { id: "2", role: Role.User };
 		const ctx = { resource: "invoice" } as const;
-		expect(checkAccess(advancedRules, user, Operation.View, ctx)).toBe(false);
+		expect(checkAccess(advancedRules, user, Operation.View, ctx, matcher)).toBe(
+			false,
+		);
 	});
 });
 
@@ -317,7 +354,7 @@ describe("file system permissions", () => {
 	}
 	type FSResource = "file";
 
-	const fsRules: readonly Rule<FSRole, FSOp, FSResource>[] = [
+	const fsRules: readonly Rule<StdMeta>[] = [
 		{ meta: { role: FSRole.Owner, resource: "file" } },
 		{ meta: { role: FSRole.Editor, operation: FSOp.Read, resource: "file" } },
 		{
@@ -334,9 +371,9 @@ describe("file system permissions", () => {
 		},
 	];
 
-	const owner: Actor<FSRole> = { id: "o1", role: FSRole.Owner };
-	const editor: Actor<FSRole> = { id: "e1", role: FSRole.Editor };
-	const viewer: Actor<FSRole> = { id: "v1", role: FSRole.Viewer };
+	const owner: Actor = { id: "o1", role: FSRole.Owner };
+	const editor: Actor = { id: "e1", role: FSRole.Editor };
+	const viewer: Actor = { id: "v1", role: FSRole.Viewer };
 
 	it("owner can delete private file", () => {
 		const ctx = {
@@ -344,7 +381,7 @@ describe("file system permissions", () => {
 			visibility: Visibility.Private,
 			ownerId: "o1",
 		} as const;
-		expect(checkAccess(fsRules, owner, FSOp.Delete, ctx)).toBe(true);
+		expect(checkAccess(fsRules, owner, FSOp.Delete, ctx, matcher)).toBe(true);
 	});
 
 	it("editor can write own file", () => {
@@ -353,7 +390,7 @@ describe("file system permissions", () => {
 			visibility: Visibility.Private,
 			ownerId: "e1",
 		} as const;
-		expect(checkAccess(fsRules, editor, FSOp.Write, ctx)).toBe(true);
+		expect(checkAccess(fsRules, editor, FSOp.Write, ctx, matcher)).toBe(true);
 	});
 
 	it("editor cannot write other's file", () => {
@@ -362,7 +399,7 @@ describe("file system permissions", () => {
 			visibility: Visibility.Private,
 			ownerId: "o1",
 		} as const;
-		expect(checkAccess(fsRules, editor, FSOp.Write, ctx)).toBe(false);
+		expect(checkAccess(fsRules, editor, FSOp.Write, ctx, matcher)).toBe(false);
 	});
 
 	it("viewer can read public file", () => {
@@ -371,7 +408,7 @@ describe("file system permissions", () => {
 			visibility: Visibility.Public,
 			ownerId: "o1",
 		} as const;
-		expect(checkAccess(fsRules, viewer, FSOp.Read, ctx)).toBe(true);
+		expect(checkAccess(fsRules, viewer, FSOp.Read, ctx, matcher)).toBe(true);
 	});
 
 	it("viewer cannot read private file of others", () => {
@@ -380,7 +417,7 @@ describe("file system permissions", () => {
 			visibility: Visibility.Private,
 			ownerId: "o1",
 		} as const;
-		expect(checkAccess(fsRules, viewer, FSOp.Read, ctx)).toBe(false);
+		expect(checkAccess(fsRules, viewer, FSOp.Read, ctx, matcher)).toBe(false);
 	});
 });
 
@@ -401,7 +438,7 @@ describe("payment permissions", () => {
 	}
 	type PayRes = "payment";
 
-	const payRules: readonly Rule<PayRole, PayOp, PayRes>[] = [
+	const payRules: readonly Rule<StdMeta>[] = [
 		{
 			meta: {
 				role: PayRole.Customer,
@@ -430,9 +467,9 @@ describe("payment permissions", () => {
 		},
 	];
 
-	const customer: Actor<PayRole> = { id: "c1", role: PayRole.Customer };
-	const merchant: Actor<PayRole> = { id: "m1", role: PayRole.Merchant };
-	const processor: Actor<PayRole> = { id: "p1", role: PayRole.Processor };
+	const customer: Actor = { id: "c1", role: PayRole.Customer };
+	const merchant: Actor = { id: "m1", role: PayRole.Merchant };
+	const processor: Actor = { id: "p1", role: PayRole.Processor };
 
 	it("customer can pay own pending payment", () => {
 		const ctx = {
@@ -440,7 +477,7 @@ describe("payment permissions", () => {
 			status: PayStatus.Pending,
 			userId: "c1",
 		} as const;
-		expect(checkAccess(payRules, customer, PayOp.Pay, ctx)).toBe(true);
+		expect(checkAccess(payRules, customer, PayOp.Pay, ctx, matcher)).toBe(true);
 	});
 
 	it("customer cannot pay completed payment", () => {
@@ -449,36 +486,48 @@ describe("payment permissions", () => {
 			status: PayStatus.Completed,
 			userId: "c1",
 		} as const;
-		expect(checkAccess(payRules, customer, PayOp.Pay, ctx)).toBe(false);
+		expect(checkAccess(payRules, customer, PayOp.Pay, ctx, matcher)).toBe(
+			false,
+		);
 	});
 
 	it("merchant can refund completed payment", () => {
 		const ctx = { resource: "payment", status: PayStatus.Completed } as const;
-		expect(checkAccess(payRules, merchant, PayOp.Refund, ctx)).toBe(true);
+		expect(checkAccess(payRules, merchant, PayOp.Refund, ctx, matcher)).toBe(
+			true,
+		);
 	});
 
 	it("merchant cannot refund pending payment", () => {
 		const ctx = { resource: "payment", status: PayStatus.Pending } as const;
-		expect(checkAccess(payRules, merchant, PayOp.Refund, ctx)).toBe(false);
+		expect(checkAccess(payRules, merchant, PayOp.Refund, ctx, matcher)).toBe(
+			false,
+		);
 	});
 
 	it("processor can cancel any payment", () => {
 		const ctx = { resource: "payment", status: PayStatus.Pending } as const;
-		expect(checkAccess(payRules, processor, PayOp.Cancel, ctx)).toBe(true);
+		expect(checkAccess(payRules, processor, PayOp.Cancel, ctx, matcher)).toBe(
+			true,
+		);
 	});
 });
 
 describe("additional helpers", () => {
 	it("matchesRule returns true without match block", () => {
-		const rule: Rule<Role, Operation, Resource> = {
+		const rule: Rule<StdMeta> = {
 			meta: { role: Role.Admin },
 		};
 		const ctx = { resource: "invoice" } as const;
-		expect(matchesRule(rule, dummyActor, Operation.View, ctx)).toBe(true);
+		expect(matchesRule(rule, dummyActor, Operation.View, ctx, matcher)).toBe(
+			true,
+		);
 	});
 
 	it("checkAccess returns false when no rules provided", () => {
 		const ctx = { resource: "invoice" } as const;
-		expect(checkAccess([], dummyActor, Operation.View, ctx)).toBe(false);
+		expect(checkAccess([], dummyActor, Operation.View, ctx, matcher)).toBe(
+			false,
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- refactor rule engine to remove fixed role/resource metadata
- require a meta matcher function for rule evaluation
- update tests and invoice example to pass matcher
- document matcher usage

## Testing
- `bun run lint`
- `bun run format`
- `bun run build`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_685083b63324832e9ba3b6d55985f50a