### PR TITLE
docs: use Meta interface in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,13 @@ enum Operation {
 
 type Resource = "invoice";
 
-const rules: readonly Rule<Role, Operation, Resource>[] = [
+interface Meta {
+  role?: Role;
+  operation?: Operation;
+  resource?: Resource;
+}
+
+const rules: readonly Rule<Meta>[] = [
   {
     meta: { role: Role.User, operation: Operation.View, resource: "invoice" },
     match: { userId: { reference: { actor: "id" } } },
@@ -134,7 +140,13 @@ enum InvoiceStatus {
 
 type Resource = "invoice";
 
-const rules: readonly Rule<Role, Operation, Resource>[] = [
+interface Meta {
+  role?: Role;
+  operation?: Operation;
+  resource?: Resource;
+}
+
+const rules: readonly Rule<Meta>[] = [
   {
     meta: { role: Role.Admin, operation: Operation.Edit, resource: "invoice" },
     match: { status: { in: [InvoiceStatus.Draft, InvoiceStatus.Pending] } },
@@ -157,7 +169,13 @@ Rules can be nested to express complex permission trees. `checkAccess` traverses
 ```ts
 import { Rule } from "@soudasuwa/permissions";
 
-export const nestedRules: readonly Rule<Role, Operation, Resource>[] = [
+interface Meta {
+  role?: Role;
+  operation?: Operation;
+  resource?: Resource;
+}
+
+export const nestedRules: readonly Rule<Meta>[] = [
   {
     meta: { role: Role.Admin },
     rules: [


### PR DESCRIPTION
## Summary
- update README to demonstrate declaring an interface
- use `Rule<Meta>` throughout examples instead of generic parameters

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68509e5a9648832eacfa2e1db4cbe25e