### PR TITLE
Add strategy-based rule engine examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ bun test
 
 ## Examples
 
-### 1. Minimal check with `checkAccess`
+### 1. Minimal check with `ResourceRoleOperationEngine`
 
-Below is a minimal example of using `checkAccess` to see if a user can pay their invoice:
+Below is a minimal example of using the built-in strategy engine to see if a user can pay their invoice:
 
 ```ts
-import { checkAccess, type Rule } from "@soudasuwa/permissions";
+import { ResourceRoleOperationEngine, type Rule } from "@soudasuwa/permissions";
 
 enum Role {
   Admin = "admin",
@@ -52,17 +52,7 @@ interface Meta {
   resource?: Resource;
 }
 
-const matcher: MetaMatcher<Meta> = (meta, actor, action, ctx) => {
-  if (!meta) return true;
-  const { role, operation, resource } = meta;
-  if (role) {
-    const roles = Array.isArray(role) ? role : [role];
-    if (!roles.includes((actor as { role?: Role }).role ?? Role.User)) return false;
-  }
-  if (resource && resource !== (ctx as { resource?: Resource }).resource) return false;
-  if (operation && operation !== action) return false;
-  return true;
-};
+const engine = new ResourceRoleOperationEngine();
 
 const rules: readonly Rule<Meta>[] = [
   {
@@ -76,8 +66,7 @@ const context = {
   resource: "invoice",
   status: InvoiceStatus.Pending,
 };
-
-const allowed = checkAccess(rules, actor, Operation.Pay, context, matcher);
+const allowed = engine.checkAccess(rules, actor, Operation.Pay, context);
 console.log(allowed); // true
 ```
 
@@ -86,7 +75,7 @@ console.log(allowed); // true
 Use the `reference` helper to compare context values to properties on the actor.
 
 ```ts
-import { checkAccess, type Rule } from "@soudasuwa/permissions";
+import { ResourceRoleOperationEngine, type Rule } from "@soudasuwa/permissions";
 
 enum Role {
   User = "user",
@@ -111,10 +100,11 @@ const rules: readonly Rule<Meta>[] = [
   },
 ];
 
+const engine = new ResourceRoleOperationEngine();
 const actor = { id: "abc", role: Role.User };
 const context = { resource: "invoice", userId: "abc" };
 
-checkAccess(rules, actor, Operation.View, context, matcher); // true
+engine.checkAccess(rules, actor, Operation.View, context); // true
 ```
 
 ### 3. `in` and `not` conditions
@@ -122,7 +112,7 @@ checkAccess(rules, actor, Operation.View, context, matcher); // true
 The engine understands both inclusion lists and negated matches.
 
 ```ts
-import { checkAccess, type Rule } from "@soudasuwa/permissions";
+import { ResourceRoleOperationEngine, type Rule } from "@soudasuwa/permissions";
 
 enum Role {
   Admin = "admin",
@@ -157,14 +147,15 @@ const rules: readonly Rule<Meta>[] = [
   },
 ];
 
+const engine = new ResourceRoleOperationEngine();
 const actor = { id: "1", role: Role.Admin };
-checkAccess(rules, actor, Operation.Edit, { resource: "invoice", status: InvoiceStatus.Draft }, matcher); // true
-checkAccess(rules, actor, Operation.Edit, { resource: "invoice", status: InvoiceStatus.Complete }, matcher); // false
+engine.checkAccess(rules, actor, Operation.Edit, { resource: "invoice", status: InvoiceStatus.Draft }); // true
+engine.checkAccess(rules, actor, Operation.Edit, { resource: "invoice", status: InvoiceStatus.Complete }); // false
 ```
 
 ### 4. Nested rules
 
-Rules can be nested to express complex permission trees. `checkAccess` traverses these `rules` arrays recursively.
+Rules can be nested to express complex permission trees. The engine traverses these `rules` arrays recursively.
 
 ```ts
 import { Rule } from "@soudasuwa/permissions";

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,4 @@
 export type { Actor, Context, Rule, MetaMatcher, Condition, } from "@/types";
 export { matchCondition } from "@/conditions";
 export { RuleEngine, AbstractRuleEngine, checkAccess, matchesRule, } from "@/engine";
+export * from "@/strategies";

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,2 +1,3 @@
 export { matchCondition } from "@/conditions";
 export { RuleEngine, AbstractRuleEngine, checkAccess, matchesRule, } from "@/engine";
+export * from "@/strategies";

--- a/dist/strategies.d.ts
+++ b/dist/strategies.d.ts
@@ -1,0 +1,43 @@
+import type { Actor, Context } from "@/types";
+import { RuleEngine } from "@/engine";
+/** Meta information for role based strategies. */
+export interface RoleMeta extends Record<string, unknown> {
+    readonly role?: string | readonly string[];
+}
+/** Meta information for role and operation strategies. */
+export interface RoleOperationMeta extends RoleMeta {
+    readonly operation?: string;
+}
+/** Meta information for resource, role and operation strategies. */
+export interface ResourceRoleOperationMeta extends RoleOperationMeta {
+    readonly resource?: string;
+}
+/**
+ * Additional attribute matching information. The `key` property refers
+ * to a field on the context that should match either a specific value
+ * or a property on the actor when `reference` is defined.
+ */
+export interface AttributeMatcher<A extends Actor = Actor> {
+    readonly key: string;
+    readonly value?: unknown;
+    readonly reference?: keyof A;
+}
+export interface ResourceRoleOperationAttributeMeta<A extends Actor = Actor> extends ResourceRoleOperationMeta {
+    readonly attribute?: AttributeMatcher<A>;
+}
+/** Role based engine implementation. */
+export declare class RoleEngine<A extends Actor = Actor, Act = string, C extends Context = Context> extends RuleEngine<RoleMeta, A, Act, C> {
+    constructor();
+}
+/** Role & operation based engine. */
+export declare class RoleOperationEngine<A extends Actor = Actor, Act = string, C extends Context = Context> extends RuleEngine<RoleOperationMeta, A, Act, C> {
+    constructor();
+}
+/** Resource, role & operation engine. */
+export declare class ResourceRoleOperationEngine<A extends Actor = Actor, Act = string, C extends Context = Context> extends RuleEngine<ResourceRoleOperationMeta, A, Act, C> {
+    constructor();
+}
+/** Resource, role, operation & attribute engine. */
+export declare class ResourceRoleOperationAttributeEngine<A extends Actor = Actor, Act = string, C extends Context = Context> extends RuleEngine<ResourceRoleOperationAttributeMeta<A>, A, Act, C> {
+    constructor();
+}

--- a/dist/strategies.js
+++ b/dist/strategies.js
@@ -13,9 +13,9 @@ const hasRole = (actor, role) => {
  */
 /** Matcher for role based meta information. */
 function matchRole(meta, actor, _action, _context) {
-    if (!meta)
+    if (!meta || meta.role === undefined)
         return true;
-    const roles = Array.isArray(meta.role) ? meta.role : [meta.role ?? ""];
+    const roles = Array.isArray(meta.role) ? meta.role : [meta.role];
     return roles.includes(actor.role ?? "");
 }
 /** Matcher for role & operation meta. */

--- a/dist/strategies.js
+++ b/dist/strategies.js
@@ -1,0 +1,76 @@
+import { RuleEngine } from "@/engine";
+/** Utility to check if an actor possesses a role. */
+const hasRole = (actor, role) => {
+    if (role === undefined)
+        return true;
+    const roles = Array.isArray(role) ? role : [role];
+    return roles.includes(actor.role ?? "");
+};
+/**
+ * Create a matcher that understands RoleMeta. Operations, resources and
+ * attributes are optional depending on the strategy used.
+ */
+const createMatcher = (options) => {
+    return (meta, actor, action, context) => {
+        if (!meta)
+            return true;
+        if (hasRole(actor, meta.role) === false)
+            return false;
+        if (options.operation &&
+            "operation" in meta &&
+            meta.operation !== undefined &&
+            meta.operation !== action) {
+            return false;
+        }
+        if (options.resource &&
+            "resource" in meta &&
+            meta.resource !== undefined &&
+            meta.resource !== context.resource) {
+            return false;
+        }
+        if (options.attribute && meta.attribute) {
+            const { key, value, reference } = meta.attribute;
+            const ctxVal = context[key];
+            if (reference !== undefined) {
+                if (ctxVal !== actor[reference])
+                    return false;
+            }
+            else if (value !== undefined) {
+                if (ctxVal !== value)
+                    return false;
+            }
+        }
+        return true;
+    };
+};
+/** Role based engine implementation. */
+export class RoleEngine extends RuleEngine {
+    constructor() {
+        super(createMatcher({}));
+    }
+}
+/** Role & operation based engine. */
+export class RoleOperationEngine extends RuleEngine {
+    constructor() {
+        super(createMatcher({ operation: true }));
+    }
+}
+/** Resource, role & operation engine. */
+export class ResourceRoleOperationEngine extends RuleEngine {
+    constructor() {
+        super(createMatcher({
+            operation: true,
+            resource: true,
+        }));
+    }
+}
+/** Resource, role, operation & attribute engine. */
+export class ResourceRoleOperationAttributeEngine extends RuleEngine {
+    constructor() {
+        super(createMatcher({
+            operation: true,
+            resource: true,
+            attribute: true,
+        }));
+    }
+}

--- a/dist/strategies.js
+++ b/dist/strategies.js
@@ -7,70 +7,69 @@ const hasRole = (actor, role) => {
     return roles.includes(actor.role ?? "");
 };
 /**
- * Create a matcher that understands RoleMeta. Operations, resources and
- * attributes are optional depending on the strategy used.
+ * Meta matcher utilities implementing progressively more advanced
+ * strategies. Each matcher builds on the previous one in line with the
+ * open-closed principle.
  */
-const createMatcher = (options) => {
-    return (meta, actor, action, context) => {
-        if (!meta)
-            return true;
-        if (hasRole(actor, meta.role) === false)
-            return false;
-        if (options.operation &&
-            "operation" in meta &&
-            meta.operation !== undefined &&
-            meta.operation !== action) {
-            return false;
-        }
-        if (options.resource &&
-            "resource" in meta &&
-            meta.resource !== undefined &&
-            meta.resource !== context.resource) {
-            return false;
-        }
-        if (options.attribute && meta.attribute) {
-            const { key, value, reference } = meta.attribute;
-            const ctxVal = context[key];
-            if (reference !== undefined) {
-                if (ctxVal !== actor[reference])
-                    return false;
-            }
-            else if (value !== undefined) {
-                if (ctxVal !== value)
-                    return false;
-            }
-        }
+/** Matcher for role based meta information. */
+function matchRole(meta, actor, _action, _context) {
+    if (!meta)
         return true;
-    };
-};
+    const roles = Array.isArray(meta.role) ? meta.role : [meta.role ?? ""];
+    return roles.includes(actor.role ?? "");
+}
+/** Matcher for role & operation meta. */
+function matchRoleOperation(meta, actor, action, context) {
+    if (matchRole(meta, actor, action, context) === false)
+        return false;
+    return meta?.operation === undefined || meta.operation === action;
+}
+/** Matcher for resource, role & operation meta. */
+function matchResourceRoleOperation(meta, actor, action, context) {
+    if (matchRoleOperation(meta, actor, action, context) === false)
+        return false;
+    const resource = context.resource;
+    return meta?.resource === undefined || meta.resource === resource;
+}
+/** Matcher for resource, role, operation & attribute meta. */
+function matchResourceRoleOperationAttribute(meta, actor, action, context) {
+    if (matchResourceRoleOperation(meta, actor, action, context) === false) {
+        return false;
+    }
+    const attribute = meta?.attribute;
+    if (!attribute)
+        return true;
+    const value = context[attribute.key];
+    if (attribute.reference !== undefined) {
+        return (value ===
+            actor[attribute.reference]);
+    }
+    if (attribute.value !== undefined) {
+        return value === attribute.value;
+    }
+    return true;
+}
 /** Role based engine implementation. */
 export class RoleEngine extends RuleEngine {
     constructor() {
-        super(createMatcher({}));
+        super(matchRole);
     }
 }
 /** Role & operation based engine. */
 export class RoleOperationEngine extends RuleEngine {
     constructor() {
-        super(createMatcher({ operation: true }));
+        super(matchRoleOperation);
     }
 }
 /** Resource, role & operation engine. */
 export class ResourceRoleOperationEngine extends RuleEngine {
     constructor() {
-        super(createMatcher({
-            operation: true,
-            resource: true,
-        }));
+        super(matchResourceRoleOperation);
     }
 }
 /** Resource, role, operation & attribute engine. */
 export class ResourceRoleOperationAttributeEngine extends RuleEngine {
     constructor() {
-        super(createMatcher({
-            operation: true,
-            resource: true,
-            attribute: true,
-        }));
+        super(matchResourceRoleOperationAttribute);
     }
 }

--- a/examples/invoice/invoice.test.ts
+++ b/examples/invoice/invoice.test.ts
@@ -1,26 +1,9 @@
 import { describe, it, expect } from "bun:test";
 
-import { checkAccess, type MetaMatcher } from "@soudasuwa/permissions";
+import { ResourceRoleOperationEngine } from "@soudasuwa/permissions";
 import { rules, Operation } from "./rules";
 
-interface StdMeta {
-	role?: string | readonly string[];
-	operation?: string;
-	resource?: string;
-}
-
-const matcher: MetaMatcher<StdMeta> = (meta, actor, action, context) => {
-	if (!meta) return true;
-	const { role, operation, resource } = meta;
-	if (role) {
-		const roles = Array.isArray(role) ? role : [role];
-		if (!roles.includes((actor as { role?: string }).role ?? "")) return false;
-	}
-	if (operation && operation !== action) return false;
-	if (resource && resource !== (context as { resource?: string }).resource)
-		return false;
-	return true;
-};
+const engine = new ResourceRoleOperationEngine();
 
 const mock = {
 	invoice: {
@@ -45,7 +28,7 @@ const mock = {
 describe("Invoice access control", () => {
 	describe("Module role", () => {
 		it("Can edit invoice in Generating status", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("module"),
 				Operation.Edit,
@@ -53,13 +36,12 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Generating"),
 					payload: { status: "Draft" },
 				},
-				matcher,
 			);
 			expect(result).toBe(true);
 		});
 
 		it("Cannot edit invoice in Draft status", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("module"),
 				Operation.Edit,
@@ -67,18 +49,16 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Draft"),
 					payload: { status: "Pending" },
 				},
-				matcher,
 			);
 			expect(result).toBe(false);
 		});
 
 		it("Cannot view Generating invoice", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("module"),
 				Operation.View,
 				mock.invoice.status("Generating"),
-				matcher,
 			);
 			expect(result).toBe(false);
 		});
@@ -86,7 +66,7 @@ describe("Invoice access control", () => {
 
 	describe("Admin role", () => {
 		it("Can edit invoice in Draft status", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("admin"),
 				Operation.Edit,
@@ -94,13 +74,12 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Draft"),
 					payload: { status: "Pending" },
 				},
-				matcher,
 			);
 			expect(result).toBe(true);
 		});
 
 		it("Can edit invoice in Pending status", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("admin"),
 				Operation.Edit,
@@ -108,13 +87,12 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Pending"),
 					payload: { status: "Draft" },
 				},
-				matcher,
 			);
 			expect(result).toBe(true);
 		});
 
 		it("Cannot edit invoice in Generating status", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("admin"),
 				Operation.Edit,
@@ -122,24 +100,22 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Generating"),
 					payload: { status: "Draft" },
 				},
-				matcher,
 			);
 			expect(result).toBe(false);
 		});
 
 		it("Can view Complete invoice", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("admin"),
 				Operation.View,
 				mock.invoice.status("Complete"),
-				matcher,
 			);
 			expect(result).toBe(true);
 		});
 
 		it("Cannot edit Complete invoice", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("admin"),
 				Operation.Edit,
@@ -147,7 +123,6 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Complete"),
 					payload: { status: "Pending" },
 				},
-				matcher,
 			);
 			expect(result).toBe(false);
 		});
@@ -155,73 +130,67 @@ describe("Invoice access control", () => {
 
 	describe("Customer role", () => {
 		it("Can view Pending invoice", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("user"),
 				Operation.View,
 				mock.invoice.status("Pending"),
-				matcher,
 			);
 			expect(result).toBe(true);
 		});
 
 		it("Can pay Pending invoice", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("user"),
 				Operation.Pay,
 				mock.invoice.status("Pending"),
-				matcher,
 			);
 			expect(result).toBe(true);
 		});
 
 		it("Cannot view Draft invoice", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("user"),
 				Operation.View,
 				mock.invoice.status("Draft"),
-				matcher,
 			);
 			expect(result).toBe(false);
 		});
 
 		it("Cannot view Generating invoice", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("user"),
 				Operation.View,
 				mock.invoice.status("Generating"),
-				matcher,
 			);
 			expect(result).toBe(false);
 		});
 
 		it("Can view Complete invoice", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("user"),
 				Operation.View,
 				mock.invoice.status("Complete"),
-				matcher,
 			);
 			expect(result).toBe(true);
 		});
 
 		it("Cannot pay Complete invoice", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("user"),
 				Operation.Pay,
 				mock.invoice.status("Complete"),
-				matcher,
 			);
 			expect(result).toBe(false);
 		});
 
 		it("Cannot pay someone else's invoice", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				{ ...mock.actor.role("user"), id: "someone-else" },
 				Operation.Pay,
@@ -229,7 +198,6 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Pending"),
 					userId: "different-user",
 				},
-				matcher,
 			);
 			expect(result).toBe(false);
 		});
@@ -237,7 +205,7 @@ describe("Invoice access control", () => {
 
 	describe("Module create permission", () => {
 		it("Can create invoice when payload.status is Generating", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("module"),
 				Operation.Create,
@@ -245,13 +213,12 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Generating"),
 					payload: { status: "Generating" },
 				},
-				matcher,
 			);
 			expect(result).toBe(true);
 		});
 
 		it("Cannot create invoice when payload.status is not Generating", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("module"),
 				Operation.Create,
@@ -259,7 +226,6 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Draft"),
 					payload: { status: "Draft" },
 				},
-				matcher,
 			);
 			expect(result).toBe(false);
 		});
@@ -267,7 +233,7 @@ describe("Invoice access control", () => {
 
 	describe("Admin create permission", () => {
 		it("Can create invoice when payload.status is not Generating", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("admin"),
 				Operation.Create,
@@ -275,13 +241,12 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Draft"),
 					payload: { status: "Draft" },
 				},
-				matcher,
 			);
 			expect(result).toBe(true);
 		});
 
 		it("Cannot create invoice when payload.status is Generating", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("admin"),
 				Operation.Create,
@@ -289,7 +254,6 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Generating"),
 					payload: { status: "Generating" },
 				},
-				matcher,
 			);
 			expect(result).toBe(false);
 		});
@@ -297,7 +261,7 @@ describe("Invoice access control", () => {
 
 	describe("User create permission", () => {
 		it("Users cannot create invoices", () => {
-			const result = checkAccess(
+			const result = engine.checkAccess(
 				rules,
 				mock.actor.role("user"),
 				Operation.Create,
@@ -305,7 +269,6 @@ describe("Invoice access control", () => {
 					...mock.invoice.status("Pending"),
 					payload: { status: "Pending" },
 				},
-				matcher,
 			);
 			expect(result).toBe(false);
 		});

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,5 @@ export {
 	checkAccess,
 	matchesRule,
 } from "@/engine";
+
+export * from "@/strategies";

--- a/src/strategies.test.ts
+++ b/src/strategies.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "bun:test";
+import {
+	RoleEngine,
+	RoleOperationEngine,
+	ResourceRoleOperationEngine,
+	ResourceRoleOperationAttributeEngine,
+	type Rule,
+	type Actor,
+} from "@/index";
+
+// ---- Shared setup ----
+interface RoleActor extends Actor {
+	role?: string;
+	id?: string;
+}
+
+const actor = (role: string, id?: string): RoleActor => ({ role, id });
+
+// ---- Role engine tests ----
+describe("RoleEngine", () => {
+	const rules: readonly Rule<{ role?: string }>[] = [
+		{ meta: { role: "admin" } },
+	];
+	const engine = new RoleEngine<RoleActor>();
+
+	it("allows matching role", () => {
+		expect(engine.checkAccess(rules, actor("admin"), "any", {})).toBe(true);
+	});
+
+	it("rejects other role", () => {
+		expect(engine.checkAccess(rules, actor("user"), "any", {})).toBe(false);
+	});
+});
+
+// ---- RoleOperation engine tests ----
+describe("RoleOperationEngine", () => {
+	const rules: readonly Rule<{ role?: string; operation?: string }>[] = [
+		{ meta: { role: "admin", operation: "delete" } },
+	];
+	const engine = new RoleOperationEngine<RoleActor, string>();
+
+	it("matches role and operation", () => {
+		expect(engine.checkAccess(rules, actor("admin"), "delete", {})).toBe(true);
+	});
+
+	it("fails wrong operation", () => {
+		expect(engine.checkAccess(rules, actor("admin"), "edit", {})).toBe(false);
+	});
+});
+
+// ---- ResourceRoleOperation engine tests ----
+describe("ResourceRoleOperationEngine", () => {
+	type Meta = { role?: string; operation?: string; resource?: string };
+	const rules: readonly Rule<Meta>[] = [
+		{ meta: { role: "admin", operation: "edit", resource: "invoice" } },
+	];
+	const engine = new ResourceRoleOperationEngine<
+		RoleActor,
+		string,
+		{ resource: string }
+	>();
+
+	it("matches role, operation and resource", () => {
+		expect(
+			engine.checkAccess(rules, actor("admin"), "edit", {
+				resource: "invoice",
+			}),
+		).toBe(true);
+	});
+
+	it("fails wrong resource", () => {
+		expect(
+			engine.checkAccess(rules, actor("admin"), "edit", { resource: "file" }),
+		).toBe(false);
+	});
+});
+
+// ---- ResourceRoleOperationAttribute engine tests ----
+describe("ResourceRoleOperationAttributeEngine", () => {
+	type Meta = {
+		role?: string;
+		operation?: string;
+		resource?: string;
+		attribute?: { key: string; reference?: keyof RoleActor; value?: unknown };
+	};
+	const rules: readonly Rule<Meta>[] = [
+		{
+			meta: {
+				role: "user",
+				operation: "view",
+				resource: "invoice",
+				attribute: { key: "userId", reference: "id" },
+			},
+		},
+	];
+	const engine = new ResourceRoleOperationAttributeEngine<
+		RoleActor,
+		string,
+		{ resource: string; userId: string }
+	>();
+
+	it("matches attribute reference", () => {
+		expect(
+			engine.checkAccess(rules, actor("user", "42"), "view", {
+				resource: "invoice",
+				userId: "42",
+			}),
+		).toBe(true);
+	});
+
+	it("fails attribute mismatch", () => {
+		expect(
+			engine.checkAccess(rules, actor("user", "41"), "view", {
+				resource: "invoice",
+				userId: "42",
+			}),
+		).toBe(false);
+	});
+});

--- a/src/strategies.ts
+++ b/src/strategies.ts
@@ -1,0 +1,144 @@
+import type { Actor, Context, MetaMatcher } from "@/types";
+import { RuleEngine } from "@/engine";
+
+/** Meta information for role based strategies. */
+export interface RoleMeta extends Record<string, unknown> {
+        readonly role?: string | readonly string[];
+}
+
+/** Meta information for role and operation strategies. */
+export interface RoleOperationMeta extends RoleMeta {
+        readonly operation?: string;
+}
+
+/** Meta information for resource, role and operation strategies. */
+export interface ResourceRoleOperationMeta extends RoleOperationMeta {
+        readonly resource?: string;
+}
+
+/**
+ * Additional attribute matching information. The `key` property refers
+ * to a field on the context that should match either a specific value
+ * or a property on the actor when `reference` is defined.
+ */
+export interface AttributeMatcher<A extends Actor = Actor> {
+	readonly key: string;
+	readonly value?: unknown;
+	readonly reference?: keyof A;
+}
+
+export interface ResourceRoleOperationAttributeMeta<A extends Actor = Actor>
+        extends ResourceRoleOperationMeta {
+        readonly attribute?: AttributeMatcher<A>;
+}
+
+/** Utility to check if an actor possesses a role. */
+const hasRole = (actor: Actor, role?: string | readonly string[]): boolean => {
+	if (role === undefined) return true;
+	const roles = Array.isArray(role) ? role : [role];
+	return roles.includes((actor as { role?: string }).role ?? "");
+};
+
+/**
+ * Create a matcher that understands RoleMeta. Operations, resources and
+ * attributes are optional depending on the strategy used.
+ */
+const createMatcher = <
+	M extends RoleMeta,
+	A extends Actor,
+	Act = string,
+	C extends Context = Context,
+>(options: {
+	operation?: boolean;
+	resource?: boolean;
+	attribute?: boolean;
+}): MetaMatcher<M, A, Act, C> => {
+	return (meta, actor, action, context) => {
+		if (!meta) return true;
+		if (hasRole(actor, meta.role) === false) return false;
+		if (
+			options.operation &&
+			"operation" in meta &&
+			meta.operation !== undefined &&
+			meta.operation !== action
+		) {
+			return false;
+		}
+		if (
+			options.resource &&
+			"resource" in meta &&
+			meta.resource !== undefined &&
+			meta.resource !== (context as { resource?: string }).resource
+		) {
+			return false;
+		}
+                if (options.attribute && (meta as Record<string, unknown>).attribute) {
+                        const { key, value, reference } = (meta as unknown as {
+                                attribute: AttributeMatcher<A>;
+                        }).attribute;
+			const ctxVal = (context as Record<string, unknown>)[key];
+			if (reference !== undefined) {
+				if (ctxVal !== (actor as Record<string, unknown>)[reference as string])
+					return false;
+			} else if (value !== undefined) {
+				if (ctxVal !== value) return false;
+			}
+		}
+		return true;
+	};
+};
+
+/** Role based engine implementation. */
+export class RoleEngine<
+	A extends Actor = Actor,
+	Act = string,
+	C extends Context = Context,
+> extends RuleEngine<RoleMeta, A, Act, C> {
+	constructor() {
+		super(createMatcher<RoleMeta, A, Act, C>({}));
+	}
+}
+
+/** Role & operation based engine. */
+export class RoleOperationEngine<
+	A extends Actor = Actor,
+	Act = string,
+	C extends Context = Context,
+> extends RuleEngine<RoleOperationMeta, A, Act, C> {
+	constructor() {
+		super(createMatcher<RoleOperationMeta, A, Act, C>({ operation: true }));
+	}
+}
+
+/** Resource, role & operation engine. */
+export class ResourceRoleOperationEngine<
+	A extends Actor = Actor,
+	Act = string,
+	C extends Context = Context,
+> extends RuleEngine<ResourceRoleOperationMeta, A, Act, C> {
+	constructor() {
+		super(
+			createMatcher<ResourceRoleOperationMeta, A, Act, C>({
+				operation: true,
+				resource: true,
+			}),
+		);
+	}
+}
+
+/** Resource, role, operation & attribute engine. */
+export class ResourceRoleOperationAttributeEngine<
+	A extends Actor = Actor,
+	Act = string,
+	C extends Context = Context,
+> extends RuleEngine<ResourceRoleOperationAttributeMeta<A>, A, Act, C> {
+	constructor() {
+		super(
+			createMatcher<ResourceRoleOperationAttributeMeta<A>, A, Act, C>({
+				operation: true,
+				resource: true,
+				attribute: true,
+			}),
+		);
+	}
+}

--- a/src/strategies.ts
+++ b/src/strategies.ts
@@ -51,8 +51,8 @@ function matchRole<
 	Act = string,
 	C extends Context = Context,
 >(meta: RoleMeta | undefined, actor: A, _action: Act, _context: C): boolean {
-	if (!meta) return true;
-	const roles = Array.isArray(meta.role) ? meta.role : [meta.role ?? ""];
+	if (!meta || meta.role === undefined) return true;
+	const roles = Array.isArray(meta.role) ? meta.role : [meta.role];
 	return roles.includes((actor as { role?: string }).role ?? "");
 }
 

--- a/src/strategies.ts
+++ b/src/strategies.ts
@@ -3,17 +3,17 @@ import { RuleEngine } from "@/engine";
 
 /** Meta information for role based strategies. */
 export interface RoleMeta extends Record<string, unknown> {
-        readonly role?: string | readonly string[];
+	readonly role?: string | readonly string[];
 }
 
 /** Meta information for role and operation strategies. */
 export interface RoleOperationMeta extends RoleMeta {
-        readonly operation?: string;
+	readonly operation?: string;
 }
 
 /** Meta information for resource, role and operation strategies. */
 export interface ResourceRoleOperationMeta extends RoleOperationMeta {
-        readonly resource?: string;
+	readonly resource?: string;
 }
 
 /**
@@ -28,8 +28,8 @@ export interface AttributeMatcher<A extends Actor = Actor> {
 }
 
 export interface ResourceRoleOperationAttributeMeta<A extends Actor = Actor>
-        extends ResourceRoleOperationMeta {
-        readonly attribute?: AttributeMatcher<A>;
+	extends ResourceRoleOperationMeta {
+	readonly attribute?: AttributeMatcher<A>;
 }
 
 /** Utility to check if an actor possesses a role. */
@@ -40,53 +40,81 @@ const hasRole = (actor: Actor, role?: string | readonly string[]): boolean => {
 };
 
 /**
- * Create a matcher that understands RoleMeta. Operations, resources and
- * attributes are optional depending on the strategy used.
+ * Meta matcher utilities implementing progressively more advanced
+ * strategies. Each matcher builds on the previous one in line with the
+ * open-closed principle.
  */
-const createMatcher = <
-	M extends RoleMeta,
-	A extends Actor,
+
+/** Matcher for role based meta information. */
+function matchRole<
+	A extends Actor = Actor,
 	Act = string,
 	C extends Context = Context,
->(options: {
-	operation?: boolean;
-	resource?: boolean;
-	attribute?: boolean;
-}): MetaMatcher<M, A, Act, C> => {
-	return (meta, actor, action, context) => {
-		if (!meta) return true;
-		if (hasRole(actor, meta.role) === false) return false;
-		if (
-			options.operation &&
-			"operation" in meta &&
-			meta.operation !== undefined &&
-			meta.operation !== action
-		) {
-			return false;
-		}
-		if (
-			options.resource &&
-			"resource" in meta &&
-			meta.resource !== undefined &&
-			meta.resource !== (context as { resource?: string }).resource
-		) {
-			return false;
-		}
-                if (options.attribute && (meta as Record<string, unknown>).attribute) {
-                        const { key, value, reference } = (meta as unknown as {
-                                attribute: AttributeMatcher<A>;
-                        }).attribute;
-			const ctxVal = (context as Record<string, unknown>)[key];
-			if (reference !== undefined) {
-				if (ctxVal !== (actor as Record<string, unknown>)[reference as string])
-					return false;
-			} else if (value !== undefined) {
-				if (ctxVal !== value) return false;
-			}
-		}
-		return true;
-	};
-};
+>(meta: RoleMeta | undefined, actor: A, _action: Act, _context: C): boolean {
+	if (!meta) return true;
+	const roles = Array.isArray(meta.role) ? meta.role : [meta.role ?? ""];
+	return roles.includes((actor as { role?: string }).role ?? "");
+}
+
+/** Matcher for role & operation meta. */
+function matchRoleOperation<
+	A extends Actor = Actor,
+	Act = string,
+	C extends Context = Context,
+>(
+	meta: RoleOperationMeta | undefined,
+	actor: A,
+	action: Act,
+	context: C,
+): boolean {
+	if (matchRole(meta, actor, action, context) === false) return false;
+	return meta?.operation === undefined || meta.operation === action;
+}
+
+/** Matcher for resource, role & operation meta. */
+function matchResourceRoleOperation<
+	A extends Actor = Actor,
+	Act = string,
+	C extends Context = Context,
+>(
+	meta: ResourceRoleOperationMeta | undefined,
+	actor: A,
+	action: Act,
+	context: C,
+): boolean {
+	if (matchRoleOperation(meta, actor, action, context) === false) return false;
+	const resource = (context as { resource?: string }).resource;
+	return meta?.resource === undefined || meta.resource === resource;
+}
+
+/** Matcher for resource, role, operation & attribute meta. */
+function matchResourceRoleOperationAttribute<
+	A extends Actor = Actor,
+	Act = string,
+	C extends Context = Context,
+>(
+	meta: ResourceRoleOperationAttributeMeta<A> | undefined,
+	actor: A,
+	action: Act,
+	context: C,
+): boolean {
+	if (matchResourceRoleOperation(meta, actor, action, context) === false) {
+		return false;
+	}
+	const attribute = meta?.attribute;
+	if (!attribute) return true;
+	const value = (context as Record<string, unknown>)[attribute.key];
+	if (attribute.reference !== undefined) {
+		return (
+			value ===
+			(actor as Record<string, unknown>)[attribute.reference as string]
+		);
+	}
+	if (attribute.value !== undefined) {
+		return value === attribute.value;
+	}
+	return true;
+}
 
 /** Role based engine implementation. */
 export class RoleEngine<
@@ -95,7 +123,7 @@ export class RoleEngine<
 	C extends Context = Context,
 > extends RuleEngine<RoleMeta, A, Act, C> {
 	constructor() {
-		super(createMatcher<RoleMeta, A, Act, C>({}));
+		super(matchRole as MetaMatcher<RoleMeta, A, Act, C>);
 	}
 }
 
@@ -106,7 +134,7 @@ export class RoleOperationEngine<
 	C extends Context = Context,
 > extends RuleEngine<RoleOperationMeta, A, Act, C> {
 	constructor() {
-		super(createMatcher<RoleOperationMeta, A, Act, C>({ operation: true }));
+		super(matchRoleOperation as MetaMatcher<RoleOperationMeta, A, Act, C>);
 	}
 }
 
@@ -118,10 +146,12 @@ export class ResourceRoleOperationEngine<
 > extends RuleEngine<ResourceRoleOperationMeta, A, Act, C> {
 	constructor() {
 		super(
-			createMatcher<ResourceRoleOperationMeta, A, Act, C>({
-				operation: true,
-				resource: true,
-			}),
+			matchResourceRoleOperation as MetaMatcher<
+				ResourceRoleOperationMeta,
+				A,
+				Act,
+				C
+			>,
 		);
 	}
 }
@@ -134,11 +164,12 @@ export class ResourceRoleOperationAttributeEngine<
 > extends RuleEngine<ResourceRoleOperationAttributeMeta<A>, A, Act, C> {
 	constructor() {
 		super(
-			createMatcher<ResourceRoleOperationAttributeMeta<A>, A, Act, C>({
-				operation: true,
-				resource: true,
-				attribute: true,
-			}),
+			matchResourceRoleOperationAttribute as MetaMatcher<
+				ResourceRoleOperationAttributeMeta<A>,
+				A,
+				Act,
+				C
+			>,
 		);
 	}
 }


### PR DESCRIPTION
## Summary
- add specific rule engine strategies
- expose strategy classes in the library
- provide unit tests demonstrating each strategy

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68514740e074832ea084360b165a8684