### PR TITLE
Add flexible rule matching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Guidelines for AI Contributors
+
+This repository contains a Node.js rule engine used in several access control scenarios.
+
+- Keep changes compatible with CommonJS (`require`) modules.
+- Ensure all modifications pass `npm test` before committing.
+- The engine should remain generic: avoid hardcoding context attributes or assuming specific resource/action names.
+- Scenario rules in `scenarioRules.js` are examples; modify them only when instructed.
+- Document new capabilities in `README.md` if features are added.
+
+To run the tests:
+
+```bash
+npm test
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Rule Engine Demo
+
+This project demonstrates a small access control rule engine written in Node.js. It uses simple JSON rules to describe who may perform an action given a context object.
+
+## Features
+
+- **Generic attribute matching** – rules reference arbitrary paths within the provided context. The engine does not expect any fixed property names.
+- **Comparison operators** – equality, `in`, `not`, value `reference`, numeric comparison (`greaterThan`, `lessThan`) and `exists` checks.
+- **Logical composition** – combine rules with `AND`, `OR` and `NOT` blocks or use arrays/multiple keys for implicit `AND` behaviour.
+- **Authorize helper** – evaluate an array of rule objects. Each rule can include an optional `when` clause that must match before its main rule is evaluated.
+- **Realistic scenarios** – `scenarioRules.js` contains example rule sets for common applications (todo apps, collaborative notes, forums and more).
+
+## Testing
+
+Run all unit tests with:
+
+```bash
+npm test
+```
+
+## Possible Future Enhancements
+
+- Support additional operators (e.g. array `contains`, pattern matching).
+- Allow custom operator plugins for domain specific logic.
+- Cache compiled rules for faster repeated authorization checks.
+- Provide tooling to validate or visualize rule configurations.

--- a/scenarioRules.js
+++ b/scenarioRules.js
@@ -1,102 +1,162 @@
-// Access control rules derived from scenarios.js with grouped resources
+// Access control rules written in a single-level format.
+// Each scenario exports an array of rule objects describing a resource, an
+// action and the condition to evaluate.  The rule engine does not care which
+// attributes exist in the context; it simply ensures that both the `resource`
+// and `action` fields match before evaluating the rule condition.
 
-const scenario1 = {
-  todo: {
-    create: { AND: [ { 'user.id': { exists: true } }, { 'resource.ownerId': { reference: 'user.id' } } ] },
-    read:   { 'resource.ownerId': { reference: 'user.id' } },
-    update: { 'resource.ownerId': { reference: 'user.id' } },
-    delete: { 'resource.ownerId': { reference: 'user.id' } }
-  }
-};
-
-const scenario2 = {
-  task: {
-    create: { AND: [ { 'user.id': { exists: true } }, { 'resource.ownerId': { reference: 'user.id' } } ] },
-    read: {
-      OR: [
-        { 'resource.ownerId': { reference: 'user.id' } },
-        { 'user.id': { in: { reference: 'resource.sharedWith' } } }
+const scenario1 = [
+  {
+    when: { resource: 'todo', action: 'create' },
+    rule: {
+      AND: [
+        { 'user.id': { exists: true } },
+        { 'item.ownerId': { reference: 'user.id' } }
       ]
-    },
-    update: {
-      OR: [
-        { 'resource.ownerId': { reference: 'user.id' } },
-        { 'user.id': { in: { reference: 'resource.sharedWith' } } }
-      ]
-    },
-    delete: { 'resource.ownerId': { reference: 'user.id' } }
+    }
+  },
+  {
+    when: { resource: 'todo', action: 'read' },
+    rule: { 'item.ownerId': { reference: 'user.id' } }
+  },
+  {
+    when: { resource: 'todo', action: 'update' },
+    rule: { 'item.ownerId': { reference: 'user.id' } }
+  },
+  {
+    when: { resource: 'todo', action: 'delete' },
+    rule: { 'item.ownerId': { reference: 'user.id' } }
   }
-};
+];
 
-const scenario3 = {
-  game: {
-    create: {
+const scenario2 = [
+  {
+    when: { resource: 'task', action: 'create' },
+    rule: {
+      AND: [
+        { 'user.id': { exists: true } },
+        { 'item.ownerId': { reference: 'user.id' } }
+      ]
+    }
+  },
+  {
+    when: { resource: 'task', action: 'read' },
+    rule: {
+      OR: [
+        { 'item.ownerId': { reference: 'user.id' } },
+        { 'user.id': { in: { reference: 'item.sharedWith' } } }
+      ]
+    }
+  },
+  {
+    when: { resource: 'task', action: 'update' },
+    rule: {
+      OR: [
+        { 'item.ownerId': { reference: 'user.id' } },
+        { 'user.id': { in: { reference: 'item.sharedWith' } } }
+      ]
+    }
+  },
+  {
+    when: { resource: 'task', action: 'delete' },
+    rule: { 'item.ownerId': { reference: 'user.id' } }
+  }
+];
+
+const scenario3 = [
+  {
+    when: { resource: 'game', action: 'create' },
+    rule: {
       AND: [
         { 'user.role': 'player' },
-        { 'user.id': { in: { reference: 'resource.participants' } } }
+        { 'user.id': { in: { reference: 'item.participants' } } }
       ]
-    },
-    move: {
+    }
+  },
+  {
+    when: { resource: 'game', action: 'move' },
+    rule: {
       AND: [
-        { 'user.id': { in: { reference: 'resource.participants' } } },
-        { 'resource.status': { not: 'complete' } }
+        { 'user.id': { in: { reference: 'item.participants' } } },
+        { 'item.status': { not: 'complete' } }
       ]
-    },
-    read: {
+    }
+  },
+  {
+    when: { resource: 'game', action: 'read' },
+    rule: {
       OR: [
-        { 'resource.status': 'complete' },
+        { 'item.status': 'complete' },
         {
           AND: [
-            { 'user.id': { in: { reference: 'resource.participants' } } },
-            { 'resource.status': { not: 'complete' } }
+            { 'user.id': { in: { reference: 'item.participants' } } },
+            { 'item.status': { not: 'complete' } }
           ]
         }
       ]
     }
   },
-  leaderboard: {
-    read: { 'user.role': { in: ['player', 'moderator'] } },
-    update: { 'user.role': 'moderator' }
+  {
+    when: { resource: 'leaderboard', action: 'read' },
+    rule: { 'user.role': { in: ['player', 'moderator'] } }
+  },
+  {
+    when: { resource: 'leaderboard', action: 'update' },
+    rule: { 'user.role': 'moderator' }
   }
-};
+];
 
-const scenario4 = {
-  note: {
-    create: {
-      OR: [
-        { 'notebook.ownerId': { reference: 'user.id' } },
-        { 'user.id': { in: { reference: 'notebook.editors' } } }
-      ]
-    },
-    read: {
-      OR: [
-        { 'notebook.ownerId': { reference: 'user.id' } },
-        { 'user.id': { in: { reference: 'notebook.editors' } } },
-        { 'user.id': { in: { reference: 'notebook.viewers' } } }
-      ]
-    },
-    update: {
-      OR: [
-        { 'notebook.ownerId': { reference: 'user.id' } },
-        { 'user.id': { in: { reference: 'notebook.editors' } } }
-      ]
-    },
-    delete: {
+const scenario4 = [
+  {
+    when: { resource: 'note', action: 'create' },
+    rule: {
       OR: [
         { 'notebook.ownerId': { reference: 'user.id' } },
         { 'user.id': { in: { reference: 'notebook.editors' } } }
       ]
     }
   },
-  notebook: {
-    delete: { 'notebook.ownerId': { reference: 'user.id' } },
-    modifySharing: { 'notebook.ownerId': { reference: 'user.id' } }
+  {
+    when: { resource: 'note', action: 'read' },
+    rule: {
+      OR: [
+        { 'notebook.ownerId': { reference: 'user.id' } },
+        { 'user.id': { in: { reference: 'notebook.editors' } } },
+        { 'user.id': { in: { reference: 'notebook.viewers' } } }
+      ]
+    }
+  },
+  {
+    when: { resource: 'note', action: 'update' },
+    rule: {
+      OR: [
+        { 'notebook.ownerId': { reference: 'user.id' } },
+        { 'user.id': { in: { reference: 'notebook.editors' } } }
+      ]
+    }
+  },
+  {
+    when: { resource: 'note', action: 'delete' },
+    rule: {
+      OR: [
+        { 'notebook.ownerId': { reference: 'user.id' } },
+        { 'user.id': { in: { reference: 'notebook.editors' } } }
+      ]
+    }
+  },
+  {
+    when: { resource: 'notebook', action: 'delete' },
+    rule: { 'notebook.ownerId': { reference: 'user.id' } }
+  },
+  {
+    when: { resource: 'notebook', action: 'modifySharing' },
+    rule: { 'notebook.ownerId': { reference: 'user.id' } }
   }
-};
+];
 
-const scenario5 = {
-  category: {
-    view: {
+const scenario5 = [
+  {
+    when: { resource: 'category', action: 'view' },
+    rule: {
       OR: [
         { 'category.isPrivate': { not: true } },
         { 'user.id': { in: { reference: 'category.allowedUsers' } } },
@@ -104,8 +164,9 @@ const scenario5 = {
       ]
     }
   },
-  topic: {
-    create: {
+  {
+    when: { resource: 'topic', action: 'create' },
+    rule: {
       AND: [
         { 'user.role': 'member' },
         {
@@ -117,24 +178,29 @@ const scenario5 = {
       ]
     }
   },
-  post: {
-    editOwn: {
+  {
+    when: { resource: 'post', action: 'editOwn' },
+    rule: {
       AND: [
         { 'user.role': 'member' },
         { 'post.authorId': { reference: 'user.id' } },
         { 'post.ageMinutes': { lessThan: 30 } }
       ]
-    },
-    editAnyModerator: {
+    }
+  },
+  {
+    when: { resource: 'post', action: 'editAnyModerator' },
+    rule: {
       AND: [
         { 'user.role': 'moderator' },
         { 'user.id': { in: { reference: 'category.moderators' } } }
       ]
     }
   },
-  user: {
-    adminDelete: { 'user.role': 'admin' }
+  {
+    when: { resource: 'user', action: 'adminDelete' },
+    rule: { 'user.role': 'admin' }
   }
-};
+];
 
 module.exports = { scenario1, scenario2, scenario3, scenario4, scenario5 };

--- a/scenarios.test.js
+++ b/scenarios.test.js
@@ -1,91 +1,146 @@
 const assert = require('node:assert');
 const { test } = require('node:test');
-const { evaluateRule } = require('./ruleEngine');
+const { authorize } = require('./ruleEngine');
 const { scenario1, scenario2, scenario3, scenario4, scenario5 } = require('./scenarioRules');
 
 // Scenario 1: Simple ToDo App
 
 test('scenario1: user can create own todo', () => {
-  const context = { user: { id: 'u1' }, resource: { ownerId: 'u1' } };
-  assert.strictEqual(evaluateRule(scenario1.todo.create, context), true);
+  const context = { resource: 'todo', action: 'create', user: { id: 'u1' }, item: { ownerId: 'u1' } };
+  assert.strictEqual(authorize(scenario1, context), true);
 });
 
 test('scenario1: user cannot read others todo', () => {
-  const context = { user: { id: 'u1' }, resource: { ownerId: 'u2' } };
-  assert.strictEqual(evaluateRule(scenario1.todo.read, context), false);
+  const context = { resource: 'todo', action: 'read', user: { id: 'u1' }, item: { ownerId: 'u2' } };
+  assert.strictEqual(authorize(scenario1, context), false);
 });
 
 // Scenario 2: Friends Tasks App
 
 test('scenario2: shared friend can update task', () => {
-  const context = { user: { id: 'bob' }, resource: { ownerId: 'alice', sharedWith: ['bob'] } };
-  assert.strictEqual(evaluateRule(scenario2.task.update, context), true);
+  const context = {
+    resource: 'task',
+    action: 'update',
+    user: { id: 'bob' },
+    item: { ownerId: 'alice', sharedWith: ['bob'] }
+  };
+  assert.strictEqual(authorize(scenario2, context), true);
 });
 
 test('scenario2: unshared user cannot read task', () => {
-  const context = { user: { id: 'charlie' }, resource: { ownerId: 'alice', sharedWith: ['bob'] } };
-  assert.strictEqual(evaluateRule(scenario2.task.read, context), false);
+  const context = {
+    resource: 'task',
+    action: 'read',
+    user: { id: 'charlie' },
+    item: { ownerId: 'alice', sharedWith: ['bob'] }
+  };
+  assert.strictEqual(authorize(scenario2, context), false);
 });
 
 // Scenario 3: Tic-Tac-Toe Game with Leaderboard
 
 test('scenario3: participant can move in active game', () => {
-  const context = { user: { id: 'p1', role: 'player' }, resource: { participants: ['p1','p2'], status: 'active' } };
-  assert.strictEqual(evaluateRule(scenario3.game.move, context), true);
+  const context = {
+    resource: 'game',
+    action: 'move',
+    user: { id: 'p1', role: 'player' },
+    item: { participants: ['p1', 'p2'], status: 'active' }
+  };
+  assert.strictEqual(authorize(scenario3, context), true);
 });
 
 test('scenario3: non participant cannot move', () => {
-  const context = { user: { id: 'x', role: 'player' }, resource: { participants: ['p1','p2'], status: 'active' } };
-  assert.strictEqual(evaluateRule(scenario3.game.move, context), false);
+  const context = {
+    resource: 'game',
+    action: 'move',
+    user: { id: 'x', role: 'player' },
+    item: { participants: ['p1', 'p2'], status: 'active' }
+  };
+  assert.strictEqual(authorize(scenario3, context), false);
 });
 
 test('scenario3: only moderator updates leaderboard', () => {
-  const context = { user: { role: 'player' } };
-  assert.strictEqual(evaluateRule(scenario3.leaderboard.update, context), false);
-  const modCtx = { user: { role: 'moderator' } };
-  assert.strictEqual(evaluateRule(scenario3.leaderboard.update, modCtx), true);
+  const context = { resource: 'leaderboard', action: 'update', user: { role: 'player' } };
+  assert.strictEqual(authorize(scenario3, context), false);
+  const modCtx = { resource: 'leaderboard', action: 'update', user: { role: 'moderator' } };
+  assert.strictEqual(authorize(scenario3, modCtx), true);
 });
 
 // Scenario 4: Collaborative Note Taking App
 
 test('scenario4: editor can create note', () => {
-  const context = { user: { id: 'e1' }, notebook: { ownerId: 'o1', editors: ['e1'] } };
-  assert.strictEqual(evaluateRule(scenario4.note.create, context), true);
+  const context = {
+    resource: 'note',
+    action: 'create',
+    user: { id: 'e1' },
+    notebook: { ownerId: 'o1', editors: ['e1'] }
+  };
+  assert.strictEqual(authorize(scenario4, context), true);
 });
 
 test('scenario4: viewer cannot update note', () => {
-  const context = { user: { id: 'v1' }, notebook: { ownerId: 'o1', viewers: ['v1'] } };
-  assert.strictEqual(evaluateRule(scenario4.note.update, context), false);
+  const context = {
+    resource: 'note',
+    action: 'update',
+    user: { id: 'v1' },
+    notebook: { ownerId: 'o1', viewers: ['v1'] }
+  };
+  assert.strictEqual(authorize(scenario4, context), false);
 });
 
 test('scenario4: owner can delete notebook', () => {
-  const context = { user: { id: 'o1' }, notebook: { ownerId: 'o1' } };
-  assert.strictEqual(evaluateRule(scenario4.notebook.delete, context), true);
+  const context = {
+    resource: 'notebook',
+    action: 'delete',
+    user: { id: 'o1' },
+    notebook: { ownerId: 'o1' }
+  };
+  assert.strictEqual(authorize(scenario4, context), true);
 });
 
 // Scenario 5: Discussion Forum
 
 test('scenario5: guest cannot create topic', () => {
-  const context = { user: { role: 'guest', id: 'g1' }, category: { isPrivate: false } };
-  assert.strictEqual(evaluateRule(scenario5.topic.create, context), false);
+  const context = {
+    resource: 'topic',
+    action: 'create',
+    user: { role: 'guest', id: 'g1' },
+    category: { isPrivate: false }
+  };
+  assert.strictEqual(authorize(scenario5, context), false);
 });
 
 test('scenario5: member edits own recent post', () => {
-  const context = { user: { role: 'member', id: 'm1' }, post: { authorId: 'm1', ageMinutes: 10 } };
-  assert.strictEqual(evaluateRule(scenario5.post.editOwn, context), true);
+  const context = {
+    resource: 'post',
+    action: 'editOwn',
+    user: { role: 'member', id: 'm1' },
+    post: { authorId: 'm1', ageMinutes: 10 }
+  };
+  assert.strictEqual(authorize(scenario5, context), true);
 });
 
 test('scenario5: moderator edits any post in category', () => {
-  const context = { user: { role: 'moderator', id: 'mod1' }, category: { moderators: ['mod1'] } };
-  assert.strictEqual(evaluateRule(scenario5.post.editAnyModerator, context), true);
+  const context = {
+    resource: 'post',
+    action: 'editAnyModerator',
+    user: { role: 'moderator', id: 'mod1' },
+    category: { moderators: ['mod1'] }
+  };
+  assert.strictEqual(authorize(scenario5, context), true);
 });
 
 test('scenario5: guest cannot view private category', () => {
-  const context = { user: { role: 'guest', id: 'g1' }, category: { isPrivate: true, allowedUsers: [] } };
-  assert.strictEqual(evaluateRule(scenario5.category.view, context), false);
+  const context = {
+    resource: 'category',
+    action: 'view',
+    user: { role: 'guest', id: 'g1' },
+    category: { isPrivate: true, allowedUsers: [] }
+  };
+  assert.strictEqual(authorize(scenario5, context), false);
 });
 
 test('scenario5: admin can delete user account', () => {
-  const context = { user: { role: 'admin' } };
-  assert.strictEqual(evaluateRule(scenario5.user.adminDelete, context), true);
+  const context = { resource: 'user', action: 'adminDelete', user: { role: 'admin' } };
+  assert.strictEqual(authorize(scenario5, context), true);
 });


### PR DESCRIPTION
## Summary
- support rule objects with generic `when` clauses
- allow multi-key objects to act as implicit AND
- update scenario rules to use `when`
- adapt authorize tests for new structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ce1675f28832eb523bc7611bcb51d