### PR TITLE
Enhance rule engine defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,10 +3,11 @@
 This repository contains a Node.js rule engine used in several access control scenarios.
 
 - Keep changes compatible with CommonJS (`require`) modules.
-- Ensure all modifications pass `npm test` before committing.
+- Ensure all modifications pass `npm test` **and** `npm run check` before committing.
 - The engine should remain generic: avoid hardcoding context attributes or assuming specific resource/action names.
 - Scenario rules in `scenarioRules.js` are examples; modify them only when instructed.
 - Document new capabilities in `README.md` if features are added.
+- Ignore the `node_modules/` folder. It contains installed packages and should never be modified or committed.
 
 To run the tests:
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ This project demonstrates a small access control rule engine written in Node.js.
 
 - **Generic attribute matching** – rules reference arbitrary paths within the provided context. The engine does not expect any fixed property names.
 - **Comparison operators** – equality, `in`, `not`, value `reference`, numeric comparison (`greaterThan`, `lessThan`) and `exists` checks.
-- **Logical composition** – combine rules with `AND`, `OR` and `NOT` blocks or use arrays/multiple keys for implicit `AND` behaviour.
+- **Logical composition** – combine rules with `AND`, `OR` and `NOT` blocks. Arrays or multiple key/value pairs automatically behave as an `AND` group.
 - **Authorize helper** – evaluate an array of rule objects. Each rule can include an optional `when` clause that must match before its main rule is evaluated.
+- **Nested rule groups** – rule objects may contain a `rules` array to share a `when` condition with multiple child rules.
+- **Nested attribute paths** – objects can be nested within a rule to group common path prefixes.
 - **Realistic scenarios** – see the `scenarios/` folder for example rule sets (todo apps, collaborative notes, forums and more).
 
 ## Testing

--- a/scenarios/scenario1.test.js
+++ b/scenarios/scenario1.test.js
@@ -16,25 +16,28 @@ const { authorize } = require("../ruleEngine");
 
 const rules = [
 	{
-		when: { resource: "todo", action: "create" },
-		rule: {
-			AND: [
-				{ "user.id": { exists: true } },
-				{ "item.ownerId": { reference: "user.id" } },
-			],
-		},
-	},
-	{
-		when: { resource: "todo", action: "read" },
-		rule: { "item.ownerId": { reference: "user.id" } },
-	},
-	{
-		when: { resource: "todo", action: "update" },
-		rule: { "item.ownerId": { reference: "user.id" } },
-	},
-	{
-		when: { resource: "todo", action: "delete" },
-		rule: { "item.ownerId": { reference: "user.id" } },
+		when: { resource: "todo" },
+		rules: [
+			{
+				when: { action: "create" },
+				rule: [
+					{ "user.id": { exists: true } },
+					{ "item.ownerId": { reference: "user.id" } },
+				],
+			},
+			{
+				when: { action: "read" },
+				rule: { "item.ownerId": { reference: "user.id" } },
+			},
+			{
+				when: { action: "update" },
+				rule: { "item.ownerId": { reference: "user.id" } },
+			},
+			{
+				when: { action: "delete" },
+				rule: { "item.ownerId": { reference: "user.id" } },
+			},
+		],
 	},
 ];
 

--- a/scenarios/scenario2.test.js
+++ b/scenarios/scenario2.test.js
@@ -18,35 +18,46 @@ const { authorize } = require("../ruleEngine");
 
 const rules = [
 	{
-		when: { resource: "task", action: "create" },
-		rule: {
-			AND: [
-				{ "user.id": { exists: true } },
-				{ "item.ownerId": { reference: "user.id" } },
-			],
-		},
-	},
-	{
-		when: { resource: "task", action: "read" },
-		rule: {
-			OR: [
-				{ "item.ownerId": { reference: "user.id" } },
-				{ "user.id": { in: { reference: "item.sharedWith" } } },
-			],
-		},
-	},
-	{
-		when: { resource: "task", action: "update" },
-		rule: {
-			OR: [
-				{ "item.ownerId": { reference: "user.id" } },
-				{ "user.id": { in: { reference: "item.sharedWith" } } },
-			],
-		},
-	},
-	{
-		when: { resource: "task", action: "delete" },
-		rule: { "item.ownerId": { reference: "user.id" } },
+		when: { resource: "task" },
+		rules: [
+			{
+				when: { action: "create" },
+				rule: [
+					{ "user.id": { exists: true } },
+					{ "item.ownerId": { reference: "user.id" } },
+				],
+			},
+			{
+				when: { action: "read" },
+				rule: {
+					OR: [
+						{ "item.ownerId": { reference: "user.id" } },
+						{
+							"user.id": {
+								in: { reference: "item.sharedWith" },
+							},
+						},
+					],
+				},
+			},
+			{
+				when: { action: "update" },
+				rule: {
+					OR: [
+						{ "item.ownerId": { reference: "user.id" } },
+						{
+							"user.id": {
+								in: { reference: "item.sharedWith" },
+							},
+						},
+					],
+				},
+			},
+			{
+				when: { action: "delete" },
+				rule: { "item.ownerId": { reference: "user.id" } },
+			},
+		],
 	},
 ];
 

--- a/scenarios/scenario3.test.js
+++ b/scenarios/scenario3.test.js
@@ -17,44 +17,60 @@ const { authorize } = require("../ruleEngine");
 
 const rules = [
 	{
-		when: { resource: "game", action: "create" },
-		rule: {
-			AND: [
-				{ "user.role": "player" },
-				{ "user.id": { in: { reference: "item.participants" } } },
-			],
-		},
-	},
-	{
-		when: { resource: "game", action: "move" },
-		rule: {
-			AND: [
-				{ "user.id": { in: { reference: "item.participants" } } },
-				{ "item.status": { not: "complete" } },
-			],
-		},
-	},
-	{
-		when: { resource: "game", action: "read" },
-		rule: {
-			OR: [
-				{ "item.status": "complete" },
-				{
-					AND: [
-						{ "user.id": { in: { reference: "item.participants" } } },
-						{ "item.status": { not: "complete" } },
+		when: { resource: "game" },
+		rules: [
+			{
+				when: { action: "create" },
+				rule: [
+					{ "user.role": "player" },
+					{
+						"user.id": {
+							in: { reference: "item.participants" },
+						},
+					},
+				],
+			},
+			{
+				when: { action: "move" },
+				rule: [
+					{
+						"user.id": {
+							in: { reference: "item.participants" },
+						},
+					},
+					{ "item.status": { not: "complete" } },
+				],
+			},
+			{
+				when: { action: "read" },
+				rule: {
+					OR: [
+						{ "item.status": "complete" },
+						[
+							{
+								"user.id": {
+									in: { reference: "item.participants" },
+								},
+							},
+							{ "item.status": { not: "complete" } },
+						],
 					],
 				},
-			],
-		},
+			},
+		],
 	},
 	{
-		when: { resource: "leaderboard", action: "read" },
-		rule: { "user.role": { in: ["player", "moderator"] } },
-	},
-	{
-		when: { resource: "leaderboard", action: "update" },
-		rule: { "user.role": "moderator" },
+		when: { resource: "leaderboard" },
+		rules: [
+			{
+				when: { action: "read" },
+				rule: { "user.role": { in: ["player", "moderator"] } },
+			},
+			{
+				when: { action: "update" },
+				rule: { "user.role": "moderator" },
+			},
+		],
 	},
 ];
 

--- a/scenarios/scenario4.test.js
+++ b/scenarios/scenario4.test.js
@@ -17,49 +17,79 @@ const { authorize } = require("../ruleEngine");
 
 const rules = [
 	{
-		when: { resource: "note", action: "create" },
-		rule: {
-			OR: [
-				{ "notebook.ownerId": { reference: "user.id" } },
-				{ "user.id": { in: { reference: "notebook.editors" } } },
-			],
-		},
+		when: { resource: "note" },
+		rules: [
+			{
+				when: { action: "create" },
+				rule: {
+					OR: [
+						{ "notebook.ownerId": { reference: "user.id" } },
+						{
+							"user.id": {
+								in: { reference: "notebook.editors" },
+							},
+						},
+					],
+				},
+			},
+			{
+				when: { action: "read" },
+				rule: {
+					OR: [
+						{ "notebook.ownerId": { reference: "user.id" } },
+						{
+							"user.id": {
+								in: { reference: "notebook.editors" },
+							},
+						},
+						{
+							"user.id": {
+								in: { reference: "notebook.viewers" },
+							},
+						},
+					],
+				},
+			},
+			{
+				when: { action: "update" },
+				rule: {
+					OR: [
+						{ "notebook.ownerId": { reference: "user.id" } },
+						{
+							"user.id": {
+								in: { reference: "notebook.editors" },
+							},
+						},
+					],
+				},
+			},
+			{
+				when: { action: "delete" },
+				rule: {
+					OR: [
+						{ "notebook.ownerId": { reference: "user.id" } },
+						{
+							"user.id": {
+								in: { reference: "notebook.editors" },
+							},
+						},
+					],
+				},
+			},
+		],
 	},
 	{
-		when: { resource: "note", action: "read" },
-		rule: {
-			OR: [
-				{ "notebook.ownerId": { reference: "user.id" } },
-				{ "user.id": { in: { reference: "notebook.editors" } } },
-				{ "user.id": { in: { reference: "notebook.viewers" } } },
-			],
-		},
-	},
-	{
-		when: { resource: "note", action: "update" },
-		rule: {
-			OR: [
-				{ "notebook.ownerId": { reference: "user.id" } },
-				{ "user.id": { in: { reference: "notebook.editors" } } },
-			],
-		},
-	},
-	{
-		when: { resource: "note", action: "delete" },
-		rule: {
-			OR: [
-				{ "notebook.ownerId": { reference: "user.id" } },
-				{ "user.id": { in: { reference: "notebook.editors" } } },
-			],
-		},
-	},
-	{
-		when: { resource: "notebook", action: "delete" },
-		rule: { "notebook.ownerId": { reference: "user.id" } },
-	},
-	{
-		when: { resource: "notebook", action: "modifySharing" },
-		rule: { "notebook.ownerId": { reference: "user.id" } },
+		when: { resource: "notebook" },
+		rules: [
+			{
+				when: { action: "delete" },
+				rule: { "notebook.ownerId": { reference: "user.id" } },
+			},
+			{
+				when: { action: "modifySharing" },
+				rule: { "notebook.ownerId": { reference: "user.id" } },
+			},
+		],
 	},
 ];
 

--- a/scenarios/scenario5.test.js
+++ b/scenarios/scenario5.test.js
@@ -37,47 +37,68 @@ const { authorize } = require("../ruleEngine");
 
 const rules = [
 	{
-		when: { resource: "category", action: "view" },
-		rule: {
-			OR: [
-				{ "category.isPrivate": { not: true } },
-				{ "user.id": { in: { reference: "category.allowedUsers" } } },
-				{ "user.role": "admin" },
-			],
-		},
-	},
-	{
-		when: { resource: "topic", action: "create" },
-		rule: {
-			AND: [
-				{ "user.role": "member" },
-				{
+		when: { resource: "category" },
+		rules: [
+			{
+				when: { action: "view" },
+				rule: {
 					OR: [
 						{ "category.isPrivate": { not: true } },
-						{ "user.id": { in: { reference: "category.allowedUsers" } } },
+						{
+							"user.id": {
+								in: { reference: "category.allowedUsers" },
+							},
+						},
+						{ "user.role": "admin" },
 					],
 				},
-			],
-		},
+			},
+		],
 	},
 	{
-		when: { resource: "post", action: "editOwn" },
-		rule: {
-			AND: [
-				{ "user.role": "member" },
-				{ "post.authorId": { reference: "user.id" } },
-				{ "post.ageMinutes": { lessThan: 30 } },
-			],
-		},
+		when: { resource: "topic" },
+		rules: [
+			{
+				when: { action: "create" },
+				rule: [
+					{ "user.role": "member" },
+					{
+						OR: [
+							{ "category.isPrivate": { not: true } },
+							{
+								"user.id": {
+									in: { reference: "category.allowedUsers" },
+								},
+							},
+						],
+					},
+				],
+			},
+		],
 	},
 	{
-		when: { resource: "post", action: "editAnyModerator" },
-		rule: {
-			AND: [
-				{ "user.role": "moderator" },
-				{ "user.id": { in: { reference: "category.moderators" } } },
-			],
-		},
+		when: { resource: "post" },
+		rules: [
+			{
+				when: { action: "editOwn" },
+				rule: [
+					{ "user.role": "member" },
+					{ "post.authorId": { reference: "user.id" } },
+					{ "post.ageMinutes": { lessThan: 30 } },
+				],
+			},
+			{
+				when: { action: "editAnyModerator" },
+				rule: [
+					{ "user.role": "moderator" },
+					{
+						"user.id": {
+							in: { reference: "category.moderators" },
+						},
+					},
+				],
+			},
+		],
 	},
 	{
 		when: { resource: "user", action: "adminDelete" },

--- a/scenarios/scenario6.test.js
+++ b/scenarios/scenario6.test.js
@@ -14,44 +14,49 @@ const { authorize } = require("../ruleEngine");
 
 const rules = [
 	{
-		// Administration may view invoices at any time
-		when: { resource: "invoice", action: "view" },
-		rule: { "user.role": "admin" },
-	},
-	{
-		// Customers may view their invoice only after generation is done
-		when: { resource: "invoice", action: "view" },
-		rule: {
-			AND: [
-				{ "user.role": "customer" },
-				{ "invoice.ownerId": { reference: "user.id" } },
-				{ "invoice.moduleStatus": { not: "generating" } },
-			],
-		},
-	},
-	{
-		// Admins may edit while generation finished and invoice not complete
-		when: { resource: "invoice", action: "edit" },
-		rule: {
-			AND: [
-				{ "user.role": "admin" },
-				{ "invoice.moduleStatus": { not: "generating" } },
-				{ "invoice.adminStatus": { in: ["draft", "pending"] } },
-			],
-		},
-	},
-	{
-		// Customers may pay their own pending invoice when available
-		when: { resource: "invoice", action: "pay" },
-		rule: {
-			AND: [
-				{ "user.role": "customer" },
-				{ "invoice.ownerId": { reference: "user.id" } },
-				{ "invoice.moduleStatus": { not: "generating" } },
-				{ "invoice.adminStatus": "pending" },
-				{ "invoice.customerStatus": "pending" },
-			],
-		},
+		when: { resource: "invoice" },
+		rules: [
+			{
+				// Administration may view invoices at any time
+				when: { action: "view" },
+				rule: { "user.role": "admin" },
+			},
+			{
+				// Customers may view their invoice only after generation is done
+				when: { action: "view" },
+				rule: {
+					"user.role": "customer",
+					invoice: {
+						ownerId: { reference: "user.id" },
+						moduleStatus: { not: "generating" },
+					},
+				},
+			},
+			{
+				// Admins may edit while generation finished and invoice not complete
+				when: { action: "edit" },
+				rule: {
+					"user.role": "admin",
+					invoice: {
+						moduleStatus: { not: "generating" },
+						adminStatus: { in: ["draft", "pending"] },
+					},
+				},
+			},
+			{
+				// Customers may pay their own pending invoice when available
+				when: { action: "pay" },
+				rule: {
+					"user.role": "customer",
+					invoice: {
+						ownerId: { reference: "user.id" },
+						moduleStatus: { not: "generating" },
+						adminStatus: "pending",
+						customerStatus: "pending",
+					},
+				},
+			},
+		],
 	},
 ];
 


### PR DESCRIPTION
## Summary
- require Biome checks before committing and mention ignored node_modules in AGENTS
- support nested rule groups in `authorize`
- document logical defaults and nested rule groups in README
- add tests for implicit AND and nested rule groups
- refactor scenario rules to use new nested syntax
- support nested path objects

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d324994f0832ea76fa6707c5f0df3