### PR TITLE
Refine access helper API

### DIFF
--- a/AccessController.js
+++ b/AccessController.js
@@ -1,0 +1,30 @@
+const { authorize } = require("./ruleEngine");
+
+class AccessController {
+	constructor(rules, context = {}) {
+		this.rules = rules;
+		this._context = { ...context };
+	}
+
+	/**
+	 * Return a new controller with merged context.
+	 * Shallow merge is used so nested values are simply replaced.
+	 */
+	context(data = {}) {
+		return new AccessController(this.rules, {
+			...this._context,
+			...data,
+		});
+	}
+
+	/**
+	 * Check access using the stored context plus any extra data.
+	 * Returns a boolean result from the rule engine.
+	 */
+	check(extra = {}) {
+		const ctx = { ...this._context, ...extra };
+		return authorize(this.rules, ctx);
+	}
+}
+
+module.exports = { AccessController };

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project demonstrates a small access control rule engine written in Node.js.
 - **Nested rule groups** – rule objects may contain a `rules` array to share a `when` condition with multiple child rules.
 - **Nested attribute paths** – objects can be nested within a rule to group common path prefixes.
 - **Realistic scenarios** – see the `scenarios/` folder for example rule sets (todo apps, collaborative notes, forums and more).
+- **AccessController** – helper class for incrementally building a context and checking access using the rule engine.
 
 ## Testing
 

--- a/accessHelper.test.js
+++ b/accessHelper.test.js
@@ -1,0 +1,78 @@
+const assert = require("node:assert");
+const { test } = require("node:test");
+const { AccessController } = require("./AccessController");
+
+const rules = [
+	{
+		when: { resource: "todo", action: "read" },
+		rule: { "item.ownerId": { reference: "user.id" } },
+	},
+];
+
+test("AccessController builds context incrementally", () => {
+	const controller = new AccessController(rules)
+		.context({ resource: "todo" })
+		.context({ action: "read" })
+		.context({ user: { id: "a" } })
+		.context({ item: { ownerId: "a" } });
+
+	assert.strictEqual(controller.check(), true);
+});
+
+test("check merges extra context", () => {
+	const controller = new AccessController(rules).context({
+		resource: "todo",
+		action: "read",
+	});
+
+	assert.strictEqual(
+		controller.check({ user: { id: "a" }, item: { ownerId: "a" } }),
+		true,
+	);
+	assert.strictEqual(
+		controller.check({ user: { id: "b" }, item: { ownerId: "a" } }),
+		false,
+	);
+});
+
+test("context returns new controller without mutating original", () => {
+	const base = new AccessController(rules).context({ resource: "todo" });
+	const withAction = base.context({ action: "read" });
+
+	assert.notStrictEqual(base, withAction);
+	assert.strictEqual(base._context.action, undefined);
+
+	// `withAction` already has action from context call
+	assert.strictEqual(
+		withAction.check({ user: { id: "a" }, item: { ownerId: "a" } }),
+		true,
+	);
+	// `base` requires action provided at check time
+	assert.strictEqual(
+		base.check({
+			action: "read",
+			user: { id: "a" },
+			item: { ownerId: "a" },
+		}),
+		true,
+	);
+	// `base` without action should fail
+	assert.strictEqual(
+		base.check({ user: { id: "a" }, item: { ownerId: "a" } }),
+		false,
+	);
+});
+
+test("context performs shallow merge", () => {
+	const base = new AccessController(rules, {
+		resource: "todo",
+		action: "read",
+		user: { id: "a" },
+		item: { ownerId: "a", extra: true },
+	});
+	const replaced = base.context({ item: { ownerId: "a" } });
+
+	assert.deepStrictEqual(replaced._context.item, { ownerId: "a" });
+	assert.deepStrictEqual(base._context.item, { ownerId: "a", extra: true });
+	assert.strictEqual(replaced.check(), true);
+});


### PR DESCRIPTION
## Summary
- simplify `AccessController` and remove `ContextBuilder`
- new `context()` method creates a new controller with shallow merged context
- update docs and tests for the new API
- expand `AccessController` test coverage

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686e3d5fd2ac832e9227d23a8c0de70c