### PR TITLE
Refactor scenario tests to use AccessController

### DIFF
--- a/scenarios/scenario1.test.js
+++ b/scenarios/scenario1.test.js
@@ -12,7 +12,7 @@
 
 const assert = require("node:assert");
 const { test } = require("node:test");
-const { authorize } = require("../ruleEngine");
+const { AccessController } = require("../AccessController");
 
 const rules = [
 	{
@@ -43,94 +43,87 @@ const rules = [
 
 module.exports = { rules };
 
+const base = new AccessController(rules).context({ resource: "todo" });
+
 // Tests
 
 test("scenario1: user can create own todo", () => {
-	const context = {
-		resource: "todo",
+	const controller = base.context({
 		action: "create",
 		user: { id: "u1" },
 		item: { ownerId: "u1" },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario1: user cannot create todo for another user", () => {
-	const context = {
-		resource: "todo",
+	const controller = base.context({
 		action: "create",
 		user: { id: "u1" },
 		item: { ownerId: "u2" },
-	};
-	assert.strictEqual(authorize(rules, context), false);
+	});
+	assert.strictEqual(controller.check(), false);
 });
 
 test("scenario1: missing user id cannot create", () => {
-	const context = {
-		resource: "todo",
+	const controller = base.context({
 		action: "create",
 		user: {},
 		item: { ownerId: "u1" },
-	};
-	assert.strictEqual(authorize(rules, context), false);
+	});
+	assert.strictEqual(controller.check(), false);
 });
 
 test("scenario1: user can read own todo", () => {
-	const context = {
-		resource: "todo",
+	const controller = base.context({
 		action: "read",
 		user: { id: "u1" },
 		item: { ownerId: "u1" },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario1: user cannot read others todo", () => {
-	const context = {
-		resource: "todo",
+	const controller = base.context({
 		action: "read",
 		user: { id: "u1" },
 		item: { ownerId: "u2" },
-	};
-	assert.strictEqual(authorize(rules, context), false);
+	});
+	assert.strictEqual(controller.check(), false);
 });
 
 test("scenario1: user can update own todo", () => {
-	const context = {
-		resource: "todo",
+	const controller = base.context({
 		action: "update",
 		user: { id: "u1" },
 		item: { ownerId: "u1" },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario1: user cannot update others todo", () => {
-	const context = {
-		resource: "todo",
+	const controller = base.context({
 		action: "update",
 		user: { id: "u1" },
 		item: { ownerId: "u2" },
-	};
-	assert.strictEqual(authorize(rules, context), false);
+	});
+	assert.strictEqual(controller.check(), false);
 });
 
 test("scenario1: user can delete own todo", () => {
-	const context = {
-		resource: "todo",
+	const controller = base.context({
 		action: "delete",
 		user: { id: "u1" },
 		item: { ownerId: "u1" },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario1: user cannot delete others todo", () => {
-	const context = {
-		resource: "todo",
+	const controller = base.context({
 		action: "delete",
 		user: { id: "u1" },
 		item: { ownerId: "u2" },
-	};
-	assert.strictEqual(authorize(rules, context), false);
+	});
+	assert.strictEqual(controller.check(), false);
 });

--- a/scenarios/scenario2.test.js
+++ b/scenarios/scenario2.test.js
@@ -14,7 +14,7 @@
 
 const assert = require("node:assert");
 const { test } = require("node:test");
-const { authorize } = require("../ruleEngine");
+const { AccessController } = require("../AccessController");
 
 const rules = [
 	{
@@ -63,104 +63,96 @@ const rules = [
 
 module.exports = { rules };
 
+const base = new AccessController(rules).context({ resource: "task" });
+
 // Tests
 
 test("scenario2: shared friend can update task", () => {
-	const context = {
-		resource: "task",
+	const controller = base.context({
 		action: "update",
 		user: { id: "bob" },
 		item: { ownerId: "alice", sharedWith: ["bob"] },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario2: owner can create task", () => {
-	const context = {
-		resource: "task",
+	const controller = base.context({
 		action: "create",
 		user: { id: "alice" },
 		item: { ownerId: "alice" },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario2: cannot create task for another user", () => {
-	const context = {
-		resource: "task",
+	const controller = base.context({
 		action: "create",
 		user: { id: "alice" },
 		item: { ownerId: "bob" },
-	};
-	assert.strictEqual(authorize(rules, context), false);
+	});
+	assert.strictEqual(controller.check(), false);
 });
 
 test("scenario2: owner can read task", () => {
-	const context = {
-		resource: "task",
+	const controller = base.context({
 		action: "read",
 		user: { id: "alice" },
 		item: { ownerId: "alice" },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario2: shared friend can read task", () => {
-	const context = {
-		resource: "task",
+	const controller = base.context({
 		action: "read",
 		user: { id: "bob" },
 		item: { ownerId: "alice", sharedWith: ["bob"] },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario2: unshared user cannot read task", () => {
-	const context = {
-		resource: "task",
+	const controller = base.context({
 		action: "read",
 		user: { id: "charlie" },
 		item: { ownerId: "alice", sharedWith: ["bob"] },
-	};
-	assert.strictEqual(authorize(rules, context), false);
+	});
+	assert.strictEqual(controller.check(), false);
 });
 
 test("scenario2: owner can update task", () => {
-	const context = {
-		resource: "task",
+	const controller = base.context({
 		action: "update",
 		user: { id: "alice" },
 		item: { ownerId: "alice" },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario2: unshared user cannot update task", () => {
-	const context = {
-		resource: "task",
+	const controller = base.context({
 		action: "update",
 		user: { id: "charlie" },
 		item: { ownerId: "alice", sharedWith: ["bob"] },
-	};
-	assert.strictEqual(authorize(rules, context), false);
+	});
+	assert.strictEqual(controller.check(), false);
 });
 
 test("scenario2: owner can delete task", () => {
-	const context = {
-		resource: "task",
+	const controller = base.context({
 		action: "delete",
 		user: { id: "alice" },
 		item: { ownerId: "alice" },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario2: shared friend cannot delete task", () => {
-	const context = {
-		resource: "task",
+	const controller = base.context({
 		action: "delete",
 		user: { id: "bob" },
 		item: { ownerId: "alice", sharedWith: ["bob"] },
-	};
-	assert.strictEqual(authorize(rules, context), false);
+	});
+	assert.strictEqual(controller.check(), false);
 });

--- a/scenarios/scenario4.test.js
+++ b/scenarios/scenario4.test.js
@@ -13,7 +13,7 @@
 
 const assert = require("node:assert");
 const { test } = require("node:test");
-const { authorize } = require("../ruleEngine");
+const { AccessController } = require("../AccessController");
 
 const rules = [
 	{
@@ -95,134 +95,124 @@ const rules = [
 
 module.exports = { rules };
 
+const baseNote = new AccessController(rules).context({ resource: "note" });
+const baseBook = new AccessController(rules).context({ resource: "notebook" });
+
 // Tests
 
 test("scenario4: editor can create note", () => {
-	const context = {
-		resource: "note",
+	const controller = baseNote.context({
 		action: "create",
 		user: { id: "e1" },
 		notebook: { ownerId: "o1", editors: ["e1"] },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario4: viewer cannot create note", () => {
-	const context = {
-		resource: "note",
+	const controller = baseNote.context({
 		action: "create",
 		user: { id: "v1" },
 		notebook: { ownerId: "o1", viewers: ["v1"] },
-	};
-	assert.strictEqual(authorize(rules, context), false);
+	});
+	assert.strictEqual(controller.check(), false);
 });
 
 test("scenario4: viewer cannot update note", () => {
-	const context = {
-		resource: "note",
+	const controller = baseNote.context({
 		action: "update",
 		user: { id: "v1" },
 		notebook: { ownerId: "o1", viewers: ["v1"] },
-	};
-	assert.strictEqual(authorize(rules, context), false);
+	});
+	assert.strictEqual(controller.check(), false);
 });
 
 test("scenario4: owner can update note", () => {
-	const context = {
-		resource: "note",
+	const controller = baseNote.context({
 		action: "update",
 		user: { id: "o1" },
 		notebook: { ownerId: "o1" },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario4: editor can update note", () => {
-	const context = {
-		resource: "note",
+	const controller = baseNote.context({
 		action: "update",
 		user: { id: "e1" },
 		notebook: { ownerId: "o1", editors: ["e1"] },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario4: viewer can read note", () => {
-	const context = {
-		resource: "note",
+	const controller = baseNote.context({
 		action: "read",
 		user: { id: "v1" },
 		notebook: { ownerId: "o1", viewers: ["v1"] },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario4: owner can delete note", () => {
-	const context = {
-		resource: "note",
+	const controller = baseNote.context({
 		action: "delete",
 		user: { id: "o1" },
 		notebook: { ownerId: "o1" },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario4: editor can delete note", () => {
-	const context = {
-		resource: "note",
+	const controller = baseNote.context({
 		action: "delete",
 		user: { id: "e1" },
 		notebook: { ownerId: "o1", editors: ["e1"] },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario4: viewer cannot delete note", () => {
-	const context = {
-		resource: "note",
+	const controller = baseNote.context({
 		action: "delete",
 		user: { id: "v1" },
 		notebook: { ownerId: "o1", viewers: ["v1"] },
-	};
-	assert.strictEqual(authorize(rules, context), false);
+	});
+	assert.strictEqual(controller.check(), false);
 });
 
 test("scenario4: owner can delete notebook", () => {
-	const context = {
-		resource: "notebook",
+	const controller = baseBook.context({
 		action: "delete",
 		user: { id: "o1" },
 		notebook: { ownerId: "o1" },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario4: non owner cannot delete notebook", () => {
-	const context = {
-		resource: "notebook",
+	const controller = baseBook.context({
 		action: "delete",
 		user: { id: "e1" },
 		notebook: { ownerId: "o1", editors: ["e1"] },
-	};
-	assert.strictEqual(authorize(rules, context), false);
+	});
+	assert.strictEqual(controller.check(), false);
 });
 
 test("scenario4: owner can modify sharing", () => {
-	const context = {
-		resource: "notebook",
+	const controller = baseBook.context({
 		action: "modifySharing",
 		user: { id: "o1" },
 		notebook: { ownerId: "o1" },
-	};
-	assert.strictEqual(authorize(rules, context), true);
+	});
+	assert.strictEqual(controller.check(), true);
 });
 
 test("scenario4: editor cannot modify sharing", () => {
-	const context = {
-		resource: "notebook",
+	const controller = baseBook.context({
 		action: "modifySharing",
 		user: { id: "e1" },
 		notebook: { ownerId: "o1", editors: ["e1"] },
-	};
-	assert.strictEqual(authorize(rules, context), false);
+	});
+	assert.strictEqual(controller.check(), false);
 });


### PR DESCRIPTION
## Summary
- switch scenario tests to the `AccessController` helper
- reduce duplication by building shared base contexts per resource

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686e4db5fad4832eaaa03ee35b58e774