### PR TITLE
Enable object OR syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project demonstrates a small access control rule engine written in Node.js.
 
 - **Generic attribute matching** – rules reference arbitrary paths within the provided context. The engine does not expect any fixed property names.
 - **Comparison operators** – equality, `in`, `not`, value `reference`, numeric comparison (`greaterThan`, `lessThan`) and `exists` checks.
-- **Logical composition** – combine rules with `AND`, `OR` and `NOT` blocks. Arrays or multiple key/value pairs automatically behave as an `AND` group.
+- **Logical composition** – combine rules with `AND`, `OR` and `NOT` blocks. Arrays or multiple key/value pairs automatically behave as an `AND` group. `OR` blocks may be an array of rules or a single object whose properties are treated as alternatives.
 - **Authorize helper** – evaluate an array of rule objects. Each rule can include an optional `when` clause that must match before its main rule is evaluated.
 - **Nested rule groups** – rule objects may contain a `rules` array to share a `when` condition with multiple child rules.
 - **Nested attribute paths** – objects can be nested within a rule to group common path prefixes.

--- a/ruleEngine.js
+++ b/ruleEngine.js
@@ -75,7 +75,11 @@ function evaluateRule(rule, context) {
 	}
 
 	if ("OR" in rule) {
-		for (const subRule of rule.OR) {
+		const sub = rule.OR;
+		const subRules = Array.isArray(sub)
+			? sub
+			: Object.entries(sub).map(([k, v]) => ({ [k]: v }));
+		for (const subRule of subRules) {
 			if (evaluateRule(subRule, context)) return true;
 		}
 		return false;

--- a/ruleEngine.test.js
+++ b/ruleEngine.test.js
@@ -66,6 +66,18 @@ test("OR match (one true)", () => {
 	assert.strictEqual(evaluateRule(rule, context), true);
 });
 
+test("OR object syntax works", () => {
+	const rule = {
+		OR: { "user.role": "admin", "resource.status": "draft" },
+	};
+	const adminCtx = { user: { role: "admin" }, resource: { status: "pending" } };
+	const draftCtx = { user: { role: "user" }, resource: { status: "draft" } };
+	const noneCtx = { user: { role: "user" }, resource: { status: "pending" } };
+	assert.strictEqual(evaluateRule(rule, adminCtx), true);
+	assert.strictEqual(evaluateRule(rule, draftCtx), true);
+	assert.strictEqual(evaluateRule(rule, noneCtx), false);
+});
+
 test("object with multiple keys is implicit AND", () => {
 	const rule = { "user.role": "admin", "resource.status": "draft" };
 	const context = {

--- a/scenarios/scenario2.test.js
+++ b/scenarios/scenario2.test.js
@@ -30,27 +30,23 @@ const rules = [
 			{
 				when: { action: "read" },
 				rule: {
-					OR: [
-						{ "item.ownerId": { reference: "user.id" } },
-						{
-							"user.id": {
-								in: { reference: "item.sharedWith" },
-							},
+					OR: {
+						"item.ownerId": { reference: "user.id" },
+						"user.id": {
+							in: { reference: "item.sharedWith" },
 						},
-					],
+					},
 				},
 			},
 			{
 				when: { action: "update" },
 				rule: {
-					OR: [
-						{ "item.ownerId": { reference: "user.id" } },
-						{
-							"user.id": {
-								in: { reference: "item.sharedWith" },
-							},
+					OR: {
+						"item.ownerId": { reference: "user.id" },
+						"user.id": {
+							in: { reference: "item.sharedWith" },
 						},
-					],
+					},
 				},
 			},
 			{

--- a/scenarios/scenario4.test.js
+++ b/scenarios/scenario4.test.js
@@ -22,14 +22,12 @@ const rules = [
 			{
 				when: { action: "create" },
 				rule: {
-					OR: [
-						{ "notebook.ownerId": { reference: "user.id" } },
-						{
-							"user.id": {
-								in: { reference: "notebook.editors" },
-							},
+					OR: {
+						"notebook.ownerId": { reference: "user.id" },
+						"user.id": {
+							in: { reference: "notebook.editors" },
 						},
-					],
+					},
 				},
 			},
 			{
@@ -53,27 +51,23 @@ const rules = [
 			{
 				when: { action: "update" },
 				rule: {
-					OR: [
-						{ "notebook.ownerId": { reference: "user.id" } },
-						{
-							"user.id": {
-								in: { reference: "notebook.editors" },
-							},
+					OR: {
+						"notebook.ownerId": { reference: "user.id" },
+						"user.id": {
+							in: { reference: "notebook.editors" },
 						},
-					],
+					},
 				},
 			},
 			{
 				when: { action: "delete" },
 				rule: {
-					OR: [
-						{ "notebook.ownerId": { reference: "user.id" } },
-						{
-							"user.id": {
-								in: { reference: "notebook.editors" },
-							},
+					OR: {
+						"notebook.ownerId": { reference: "user.id" },
+						"user.id": {
+							in: { reference: "notebook.editors" },
 						},
-					],
+					},
 				},
 			},
 		],

--- a/scenarios/scenario5.test.js
+++ b/scenarios/scenario5.test.js
@@ -42,15 +42,13 @@ const rules = [
 			{
 				when: { action: "view" },
 				rule: {
-					OR: [
-						{ "category.isPrivate": { not: true } },
-						{
-							"user.id": {
-								in: { reference: "category.allowedUsers" },
-							},
+					OR: {
+						"category.isPrivate": { not: true },
+						"user.id": {
+							in: { reference: "category.allowedUsers" },
 						},
-						{ "user.role": "admin" },
-					],
+						"user.role": "admin",
+					},
 				},
 			},
 		],


### PR DESCRIPTION
## Summary
- allow `OR` rules to be expressed as an object
- test OR object syntax
- use new syntax in scenario2
- document the new capability

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e53808aac832ea739e8a209fa18b9