### PR TITLE
Refactor evaluator to compute trace nodes

### DIFF
--- a/AccessController.js
+++ b/AccessController.js
@@ -1,17 +1,13 @@
 const { DefaultEvaluator } = require("./ruleEngine");
 
 class AccessController {
-	constructor(rules, options = {}) {
-		if ("evaluator" in options || "context" in options) {
-			const { context = {}, evaluator = new DefaultEvaluator() } = options;
-			this._context = { ...context };
-			this.evaluator = evaluator;
-		} else {
-			// Backwards compatibility: second argument was context object
-			this._context = { ...options };
-			this.evaluator = new DefaultEvaluator();
-		}
+	constructor(
+		rules,
+		{ context = {}, evaluator = new DefaultEvaluator() } = {},
+	) {
 		this.rules = rules;
+		this._context = { ...context };
+		this.evaluator = evaluator;
 	}
 
 	context(data = {}) {

--- a/README.md
+++ b/README.md
@@ -5,13 +5,100 @@ This project demonstrates a small access control rule engine written in Node.js.
 ## Features
 
 - **Generic attribute matching** – rules reference arbitrary paths within the provided context. The engine does not expect any fixed property names.
-- **Comparison operators** – equality, `in`, `not`, value `reference`, numeric comparison (`greaterThan`, `lessThan`) and `exists` checks.
-- **Logical composition** – combine rules with `AND`, `OR` and `NOT` blocks. Arrays or multiple key/value pairs automatically behave as an `AND` group. `OR` blocks may be an array of rules or a single object whose properties are treated as alternatives.
+- **Comparison operators** – equality, `in`, `not`, value `reference`, numeric comparison (`greaterThan`, `lessThan`) and `exists` checks. Custom comparison handlers can be injected for domain specific operators.
+- **Logical composition** – combine rules with `AND`, `OR` and `NOT` blocks. Arrays or multiple key/value pairs automatically behave as an `AND` group. `OR` blocks may be an array of rules or a single object whose properties are treated as alternatives. Custom logic handlers can be injected for new operators like `XOR`.
 - **Authorize helper** – evaluate an array of rule objects. Each rule can include an optional `when` clause that must match before its main rule is evaluated.
 - **Nested rule groups** – rule objects may contain a `rules` array to share a `when` condition with multiple child rules.
 - **Nested attribute paths** – objects can be nested within a rule to group common path prefixes.
 - **Realistic scenarios** – see the `scenarios/` folder for example rule sets (todo apps, collaborative notes, forums and more).
 - **AccessController** – helper class for incrementally building a context and checking access using the rule engine.
+- **Pluggable evaluator** – provide custom logic or comparison handlers when creating an `AccessController`.
+- **Custom context resolver** – override how attribute paths resolve to support different path syntaxes or lookups.
+- **Custom rule node handlers** – define alternative rule shapes by providing node interpreters.
+- **Functional rule builder** – compose rules with helpers like `field`, `ref`, `and`, `or` and `not`.
+- **Evaluation trace** – `evaluate` and `authorize` return a tree of results so you can inspect how a rule was processed. `AccessController.pemit()` exposes this tree.
+
+### Custom evaluator example
+
+```javascript
+const xorLogic = {
+  match: (node) => typeof node === "object" && node !== null && "XOR" in node,
+  evaluate: (node, ctx, ev) => {
+    const items = Array.isArray(node.XOR)
+      ? node.XOR
+      : Object.entries(node.XOR).map(([k, v]) => ({ [k]: v }));
+    return items.filter((r) => ev.evaluate(r, ctx).passed).length === 1;
+  },
+};
+
+const controller = new AccessController(rules, {
+  evaluator: new DefaultEvaluator({ logic: [xorLogic] }),
+});
+```
+
+### Custom comparison handler example
+
+```javascript
+const startsWith = {
+  match: (_, exp) => typeof exp === "object" && exp !== null && "startsWith" in exp,
+  evaluate: (attr, exp, ctx) => {
+    const value = attr.split('.').reduce((o, k) => (o ? o[k] : undefined), ctx);
+    return typeof value === 'string' && value.startsWith(exp.startsWith);
+  },
+};
+
+const controller = new AccessController(rules, {
+  evaluator: new DefaultEvaluator({ compare: [startsWith] }),
+});
+```
+
+### Custom context resolver example
+
+```javascript
+const colonResolver = {
+  resolve: (path, ctx) =>
+    path.split(":").reduce((o, k) => (o ? o[k] : undefined), ctx),
+};
+
+const controller = new AccessController(rules, {
+  evaluator: new DefaultEvaluator({ contextResolver: colonResolver }),
+});
+```
+
+### Custom rule node handler example
+
+```javascript
+const allowIf = {
+  match: (node) => typeof node === "object" && node !== null && "allowIf" in node,
+  evaluate: (node, ctx, ev) => ev.evaluate(node.allowIf, ctx),
+};
+
+const controller = new AccessController(rules, {
+  evaluator: new DefaultEvaluator({ nodes: [allowIf] }),
+});
+```
+
+### Functional rule builder example
+
+```javascript
+const { field, ref, and, not } = require("./ruleEngine");
+
+const rule = and(
+  field("user.id", ref("item.ownerId")),
+  not(field("item.status", "archived"))
+);
+
+const controller = new AccessController([{ rule }]);
+const okCtx = {
+  user: { id: "u1" },
+  item: { ownerId: "u1", status: "active" },
+};
+const result = controller.pemit(okCtx);
+console.log(result.passed); // true
+
+// Inspect evaluation trace
+console.dir(result, { depth: null });
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project demonstrates a small access control rule engine written in Node.js.
 - **Realistic scenarios** – see the `scenarios/` folder for example rule sets (todo apps, collaborative notes, forums and more).
 - **AccessController** – helper class for incrementally building a context and checking access using the rule engine.
 - **Pluggable evaluator** – provide custom logic or comparison handlers when creating an `AccessController`.
+- **Pattern-based engine** – logic and comparison handlers match rule shapes rather than strings, making the system easy to extend.
 - **Custom context resolver** – override how attribute paths resolve to support different path syntaxes or lookups.
 - **Custom rule node handlers** – define alternative rule shapes by providing node interpreters.
 - **Functional rule builder** – compose rules with helpers like `field`, `ref`, `and`, `or` and `not`.

--- a/accessHelper.test.js
+++ b/accessHelper.test.js
@@ -94,7 +94,7 @@ test("custom evaluator can be provided", () => {
 		logic: [xorLogic],
 	});
 	const controller = new AccessController(
-		[{ rule: { XOR: [{ a: true }, { b: true }] } }],
+		[{ XOR: [{ a: true }, { b: true }] }],
 		{ evaluator },
 	);
 	assert.strictEqual(controller.check({ a: true }), true);
@@ -111,7 +111,7 @@ test("custom context resolver via evaluator", () => {
 		contextResolver: colonResolver,
 	});
 	const controller = new AccessController(
-		[{ rule: { "user:id": { reference: "item:ownerId" } } }],
+		[{ "user:id": { reference: "item:ownerId" } }],
 		{ evaluator, context: { user: { id: "u" }, item: { ownerId: "u" } } },
 	);
 	assert.strictEqual(controller.check(), true);
@@ -135,7 +135,7 @@ test("custom rule node handler via evaluator", () => {
 });
 
 test("pemit returns evaluation tree", () => {
-	const controller = new AccessController([{ rule: { flag: true } }], {
+	const controller = new AccessController([{ flag: true }], {
 		context: { flag: true },
 	});
 	const result = controller.pemit();

--- a/accessHelper.test.js
+++ b/accessHelper.test.js
@@ -65,10 +65,12 @@ test("context returns new controller without mutating original", () => {
 
 test("context performs shallow merge", () => {
 	const base = new AccessController(rules, {
-		resource: "todo",
-		action: "read",
-		user: { id: "a" },
-		item: { ownerId: "a", extra: true },
+		context: {
+			resource: "todo",
+			action: "read",
+			user: { id: "a" },
+			item: { ownerId: "a", extra: true },
+		},
 	});
 	const replaced = base.context({ item: { ownerId: "a" } });
 

--- a/ruleEngine.js
+++ b/ruleEngine.js
@@ -2,144 +2,366 @@
 // Access Control Rule Evaluator
 // ----------------------------------------
 
-function getValue(path, context) {
-	const parts = path.split(".");
-	return parts.reduce((obj, key) => (obj ? obj[key] : undefined), context);
-}
+const defaultResolver = {
+	resolve(path, ctx) {
+		return path
+			.split(".")
+			.reduce((obj, key) => (obj ? obj[key] : undefined), ctx);
+	},
+};
 
-function compare(attr, expected, context) {
-	const actual = getValue(attr, context);
+const defaultLogic = [
+	{
+		type: "AND",
+		match: Array.isArray,
+		evaluate: (node, ctx, ev) =>
+			node.every((r) => ev.evaluateRule(r, ctx).passed),
+	},
+	{
+		type: "AND",
+		match: (n) => typeof n === "object" && n !== null && "AND" in n,
+		evaluate: (n, ctx, ev) => {
+			const arr = Array.isArray(n.AND)
+				? n.AND
+				: Object.entries(n.AND).map(([k, v]) => ({ [k]: v }));
+			return arr.every((r) => ev.evaluateRule(r, ctx).passed);
+		},
+	},
+	{
+		type: "OR",
+		match: (n) => typeof n === "object" && n !== null && "OR" in n,
+		evaluate: (n, ctx, ev) => {
+			const sub = n.OR;
+			const arr = Array.isArray(sub)
+				? sub
+				: Object.entries(sub).map(([k, v]) => ({ [k]: v }));
+			return arr.some((r) => ev.evaluateRule(r, ctx).passed);
+		},
+	},
+	{
+		type: "NOT",
+		match: (n) => typeof n === "object" && n !== null && "NOT" in n,
+		evaluate: (n, ctx, ev) => !ev.evaluateRule(n.NOT, ctx).passed,
+	},
+];
 
-	if (typeof expected === "object" && expected !== null) {
-		if ("in" in expected) {
-			const arr =
-				typeof expected.in === "object" &&
-				expected.in !== null &&
-				"reference" in expected.in
-					? getValue(expected.in.reference, context)
-					: expected.in;
-			return Array.isArray(arr) && arr.includes(actual);
-		}
-		if ("not" in expected) {
-			return actual !== expected.not;
-		}
-		if ("reference" in expected) {
-			const ref = getValue(expected.reference, context);
-			return actual === ref;
-		}
-		if ("greaterThan" in expected) {
-			return actual > expected.greaterThan;
-		}
-		if ("lessThan" in expected) {
-			return actual < expected.lessThan;
-		}
-		if ("exists" in expected) {
-			return expected.exists ? actual !== undefined : actual === undefined;
-		}
-		return false;
+const inCompare = {
+	type: "in",
+	match: (_, exp) => typeof exp === "object" && exp !== null && "in" in exp,
+	evaluate(attr, exp, ctx, ev) {
+		const actual = ev.contextResolver.resolve(attr, ctx);
+		const arr =
+			typeof exp.in === "object" && exp.in !== null && "reference" in exp.in
+				? ev.contextResolver.resolve(exp.in.reference, ctx)
+				: exp.in;
+		return Array.isArray(arr) && arr.includes(actual);
+	},
+};
+
+const notCompare = {
+	type: "not",
+	match: (_, exp) => typeof exp === "object" && exp !== null && "not" in exp,
+	evaluate(attr, exp, ctx, ev) {
+		const actual = ev.contextResolver.resolve(attr, ctx);
+		return actual !== exp.not;
+	},
+};
+
+const referenceCompare = {
+	type: "reference",
+	match: (_, exp) =>
+		typeof exp === "object" && exp !== null && "reference" in exp,
+	evaluate(attr, exp, ctx, ev) {
+		const actual = ev.contextResolver.resolve(attr, ctx);
+		const ref = ev.contextResolver.resolve(exp.reference, ctx);
+		return actual === ref;
+	},
+};
+
+const greaterThanCompare = {
+	type: "greaterThan",
+	match: (_, exp) =>
+		typeof exp === "object" && exp !== null && "greaterThan" in exp,
+	evaluate(attr, exp, ctx, ev) {
+		const actual = ev.contextResolver.resolve(attr, ctx);
+		return actual > exp.greaterThan;
+	},
+};
+
+const lessThanCompare = {
+	type: "lessThan",
+	match: (_, exp) =>
+		typeof exp === "object" && exp !== null && "lessThan" in exp,
+	evaluate(attr, exp, ctx, ev) {
+		const actual = ev.contextResolver.resolve(attr, ctx);
+		return actual < exp.lessThan;
+	},
+};
+
+const existsCompare = {
+	type: "exists",
+	match: (_, exp) => typeof exp === "object" && exp !== null && "exists" in exp,
+	evaluate(attr, exp, ctx, ev) {
+		const actual = ev.contextResolver.resolve(attr, ctx);
+		return exp.exists ? actual !== undefined : actual === undefined;
+	},
+};
+
+const defaultCompare = [
+	inCompare,
+	notCompare,
+	referenceCompare,
+	greaterThanCompare,
+	lessThanCompare,
+	existsCompare,
+];
+
+const defaultNodes = [
+	{
+		type: "rule-group",
+		match: (n) =>
+			typeof n === "object" &&
+			n !== null &&
+			"when" in n &&
+			Array.isArray(n.rules),
+		evaluate: (n, ctx, ev) => {
+			const whenRes = ev.evaluateRule(n.when, ctx);
+			const ruleRes = ev.authorizeRules(n.rules, ctx);
+			return {
+				type: "rule-group",
+				passed: whenRes.passed && ruleRes.passed,
+				children: [whenRes, ruleRes],
+			};
+		},
+	},
+	{
+		type: "when-rule",
+		match: (n) =>
+			typeof n === "object" && n !== null && "when" in n && "rule" in n,
+		evaluate: (n, ctx, ev) => {
+			const whenRes = ev.evaluateRule(n.when, ctx);
+			const ruleRes = ev.evaluateRule(n.rule, ctx);
+			return {
+				type: "when-rule",
+				passed: whenRes.passed && ruleRes.passed,
+				children: [whenRes, ruleRes],
+			};
+		},
+	},
+	{
+		type: "rule-wrapper",
+		match: (n) => typeof n === "object" && n !== null && "rule" in n,
+		evaluate: (n, ctx, ev) => ev.evaluateRule(n.rule, ctx),
+	},
+	{
+		type: "when-wrapper",
+		match: (n) => typeof n === "object" && n !== null && "when" in n,
+		evaluate: (n, ctx, ev) => ev.evaluateRule(n.when, ctx),
+	},
+	{
+		type: "object",
+		match: (n) => typeof n === "object" && n !== null,
+		evaluate: (n, ctx, ev) => ev.evaluateRule(n, ctx),
+	},
+];
+
+class DefaultEvaluator {
+	constructor(options = {}) {
+		const {
+			logic = [],
+			compare = [],
+			nodes = [],
+			contextResolver = defaultResolver,
+		} = options;
+		this.logicHandlers = [...defaultLogic, ...logic];
+		this.compareHandlers = [...defaultCompare, ...compare];
+		this.nodeHandlers = [...nodes, ...defaultNodes];
+		this.contextResolver = contextResolver;
+	}
+	isComparison(attr, obj) {
+		return this.compareHandlers.some((c) => c.match(attr, obj));
 	}
 
-	return actual === expected;
+	compare(attr, expected, ctx) {
+		for (const cmp of this.compareHandlers) {
+			if (cmp.match(attr, expected)) {
+				const actual = this.contextResolver.resolve(attr, ctx);
+				const res = cmp.evaluate(attr, expected, ctx, this);
+				const node =
+					res && typeof res === "object" && "passed" in res
+						? { type: cmp.type || res.type || "compare", ...res }
+						: {
+								type: cmp.type || "compare",
+								passed: !!res,
+							};
+				return {
+					...node,
+					path: attr,
+					value: actual,
+					expected:
+						typeof expected === "object" &&
+						expected !== null &&
+						"in" in expected
+							? expected.in
+							: expected,
+				};
+			}
+		}
+		const actual = this.contextResolver.resolve(attr, ctx);
+		const passed = actual === expected;
+		return { type: "compare", passed, path: attr, value: actual, expected };
+	}
+
+	computeChildren(rule, ctx) {
+		if (Array.isArray(rule)) {
+			return rule.map((r) => this.evaluateRule(r, ctx));
+		}
+		if (typeof rule === "object" && rule !== null) {
+			if ("AND" in rule) {
+				const arr = Array.isArray(rule.AND)
+					? rule.AND
+					: Object.entries(rule.AND).map(([k, v]) => ({ [k]: v }));
+				return arr.map((r) => this.evaluateRule(r, ctx));
+			}
+			if ("OR" in rule) {
+				const sub = rule.OR;
+				const arr = Array.isArray(sub)
+					? sub
+					: Object.entries(sub).map(([k, v]) => ({ [k]: v }));
+				return arr.map((r) => this.evaluateRule(r, ctx));
+			}
+			if ("NOT" in rule) {
+				return [this.evaluateRule(rule.NOT, ctx)];
+			}
+		}
+		return [];
+	}
+
+	evaluateNode(node, ctx) {
+		if (typeof node !== "object" || node === null) {
+			return { type: "node", passed: false };
+		}
+		for (const h of this.nodeHandlers) {
+			if (h.match(node)) {
+				const res = h.evaluate(node, ctx, this);
+				return res && typeof res === "object" && "passed" in res
+					? { type: h.type || res.type || "node", ...res }
+					: { type: h.type || "node", passed: !!res };
+			}
+		}
+		return { type: "node", passed: false };
+	}
+
+	evaluateRule(rule, ctx) {
+		for (const h of this.logicHandlers) {
+			if (h.match(rule)) {
+				const res = h.evaluate(rule, ctx, this);
+				if (res && typeof res === "object" && "passed" in res) {
+					return { type: h.type || res.type || "logic", ...res };
+				}
+				const children = this.computeChildren(rule, ctx);
+				return { type: h.type || "logic", passed: !!res, children };
+			}
+		}
+
+		if (typeof rule !== "object" || rule === null) {
+			return { type: "invalid", passed: false };
+		}
+
+		const entries = Object.entries(rule);
+		if (entries.length > 1) {
+			const children = entries.map(([k, v]) =>
+				this.evaluateRule({ [k]: v }, ctx),
+			);
+			return {
+				type: "AND",
+				passed: children.every((c) => c.passed),
+				children,
+			};
+		}
+
+		const [key, expected] = entries[0];
+
+		if (
+			typeof expected === "object" &&
+			expected !== null &&
+			!this.isComparison(key, expected)
+		) {
+			const children = Object.entries(expected).map(([subKey, subVal]) =>
+				this.evaluateRule({ [`${key}.${subKey}`]: subVal }, ctx),
+			);
+			return {
+				type: "AND",
+				passed: children.every((c) => c.passed),
+				children,
+			};
+		}
+
+		return this.compare(key, expected, ctx);
+	}
+
+	evaluate(rule, ctx) {
+		return this.evaluateRule(rule, ctx);
+	}
+
+	authorizeRules(rules, ctx) {
+		if (!Array.isArray(rules)) {
+			return { type: "rules", passed: false, children: [] };
+		}
+		const children = rules.map((r) => this.evaluateNode(r, ctx));
+		return { type: "rules", passed: children.some((c) => c.passed), children };
+	}
+
+	authorize(rules, ctx) {
+		return this.authorizeRules(rules, ctx);
+	}
 }
 
-function isComparison(obj) {
-	return (
-		obj &&
-		typeof obj === "object" &&
-		("in" in obj ||
-			"not" in obj ||
-			"reference" in obj ||
-			"greaterThan" in obj ||
-			"lessThan" in obj ||
-			"exists" in obj)
+const defaultEvaluator = new DefaultEvaluator();
+
+function unwrap(value) {
+	return value && typeof value.toJSON === "function" ? value.toJSON() : value;
+}
+
+function wrap(obj) {
+	const raw = Object.fromEntries(
+		Object.entries(obj).map(([k, v]) => [k, unwrap(v)]),
 	);
+	return { ...raw, toJSON: () => raw };
 }
 
-function evaluateRule(rule, context) {
-	if (Array.isArray(rule)) {
-		for (const r of rule) {
-			if (!evaluateRule(r, context)) return false;
-		}
-		return true;
-	}
-
-	if (typeof rule !== "object" || rule === null) {
-		return false;
-	}
-
-	if ("AND" in rule) {
-		for (const subRule of rule.AND) {
-			if (!evaluateRule(subRule, context)) return false;
-		}
-		return true;
-	}
-
-	if ("OR" in rule) {
-		const sub = rule.OR;
-		const subRules = Array.isArray(sub)
-			? sub
-			: Object.entries(sub).map(([k, v]) => ({ [k]: v }));
-		for (const subRule of subRules) {
-			if (evaluateRule(subRule, context)) return true;
-		}
-		return false;
-	}
-
-	if ("NOT" in rule) {
-		return !evaluateRule(rule.NOT, context);
-	}
-
-	const entries = Object.entries(rule);
-	if (entries.length > 1) {
-		// Treat multiple key/value pairs as an implicit AND
-		for (const [k, v] of entries) {
-			if (!evaluateRule({ [k]: v }, context)) return false;
-		}
-		return true;
-	}
-
-	const [key, expected] = entries[0];
-
-	if (
-		typeof expected === "object" &&
-		expected !== null &&
-		!isComparison(expected)
-	) {
-		// Nested path object: expand keys with prefix
-		for (const [subKey, subVal] of Object.entries(expected)) {
-			const nested = { [`${key}.${subKey}`]: subVal };
-			if (!evaluateRule(nested, context)) return false;
-		}
-		return true;
-	}
-
-	return compare(key, expected, context);
-}
-// Determine whether a context is allowed under a rule set.
-// The rule engine does not know or care which attributes are present in the
-// context. Each rule is simply evaluated and if any rule returns true, access
-// is granted.
-// Evaluate a list of rules against a context. Each rule may contain an optional
-// `when` property that itself is a rule evaluated first. If the `when` rule
-// matches, the engine then evaluates the rule's `rule` property. Access is
-// granted if any rule passes. The engine does not expect any specific attribute
-// names in either the rules or the context.
-function authorize(rules, context) {
-	if (!Array.isArray(rules)) return false;
-	return rules.some((r) => {
-		if (typeof r !== "object" || r === null) return false;
-		const when = "when" in r ? r.when : undefined;
-
-		if (when && !evaluateRule(when, context)) return false;
-
-		if (Array.isArray(r.rules)) {
-			return authorize(r.rules, context);
-		}
-
-		const rule = "rule" in r ? r.rule : undefined;
-		if (rule) return evaluateRule(rule, context);
-		return evaluateRule(when, context);
-	});
+function field(path, expected) {
+	return wrap({ [path]: unwrap(expected) });
 }
 
-module.exports = { evaluateRule, authorize };
+function ref(path) {
+	return wrap({ reference: path });
+}
+
+function and(...rules) {
+	return wrap({ AND: rules.map(unwrap) });
+}
+
+function or(...rules) {
+	return wrap({ OR: rules.map(unwrap) });
+}
+
+function not(rule) {
+	return wrap({ NOT: unwrap(rule) });
+}
+
+function fromJSON(obj) {
+	return wrap(obj);
+}
+
+module.exports = {
+	DefaultEvaluator,
+	evaluateRule: defaultEvaluator.evaluate.bind(defaultEvaluator),
+	authorize: defaultEvaluator.authorize.bind(defaultEvaluator),
+	field,
+	ref,
+	and,
+	or,
+	not,
+	fromJSON,
+};

--- a/ruleEngine.test.js
+++ b/ruleEngine.test.js
@@ -1,6 +1,15 @@
 const assert = require("node:assert");
 const { test } = require("node:test");
-const { evaluateRule, authorize } = require("./ruleEngine");
+const {
+	evaluateRule,
+	authorize,
+	DefaultEvaluator,
+	field,
+	ref,
+	and,
+	not,
+	fromJSON,
+} = require("./ruleEngine");
 
 // ----------------------------------------
 // Basic Equality
@@ -9,13 +18,13 @@ const { evaluateRule, authorize } = require("./ruleEngine");
 test("Equal match", () => {
 	const rule = { "user.role": "admin" };
 	const context = { user: { role: "admin" } };
-	assert.strictEqual(evaluateRule(rule, context), true);
+	assert.strictEqual(evaluateRule(rule, context).passed, true);
 });
 
 test("Equal mismatch", () => {
 	const rule = { "user.role": "admin" };
 	const context = { user: { role: "customer" } };
-	assert.strictEqual(evaluateRule(rule, context), false);
+	assert.strictEqual(evaluateRule(rule, context).passed, false);
 });
 
 // ----------------------------------------
@@ -25,25 +34,25 @@ test("Equal mismatch", () => {
 test("In operator match", () => {
 	const rule = { "resource.status": { in: ["draft", "pending"] } };
 	const context = { resource: { status: "pending" } };
-	assert.strictEqual(evaluateRule(rule, context), true);
+	assert.strictEqual(evaluateRule(rule, context).passed, true);
 });
 
 test("In operator miss", () => {
 	const rule = { "resource.status": { in: ["draft", "pending"] } };
 	const context = { resource: { status: "complete" } };
-	assert.strictEqual(evaluateRule(rule, context), false);
+	assert.strictEqual(evaluateRule(rule, context).passed, false);
 });
 
 test("Not operator match", () => {
 	const rule = { action: { not: "edit" } };
 	const context = { action: "view" };
-	assert.strictEqual(evaluateRule(rule, context), true);
+	assert.strictEqual(evaluateRule(rule, context).passed, true);
 });
 
 test("Reference match", () => {
 	const rule = { "resource.ownerId": { reference: "user.id" } };
 	const context = { user: { id: "123" }, resource: { ownerId: "123" } };
-	assert.strictEqual(evaluateRule(rule, context), true);
+	assert.strictEqual(evaluateRule(rule, context).passed, true);
 });
 
 // ----------------------------------------
@@ -55,7 +64,7 @@ test("AND match", () => {
 		AND: [{ "user.role": "admin" }, { "resource.status": "draft" }],
 	};
 	const context = { user: { role: "admin" }, resource: { status: "draft" } };
-	assert.strictEqual(evaluateRule(rule, context), true);
+	assert.strictEqual(evaluateRule(rule, context).passed, true);
 });
 
 test("OR match (one true)", () => {
@@ -63,7 +72,7 @@ test("OR match (one true)", () => {
 		OR: [{ "user.role": "admin" }, { "user.role": "manager" }],
 	};
 	const context = { user: { role: "manager" } };
-	assert.strictEqual(evaluateRule(rule, context), true);
+	assert.strictEqual(evaluateRule(rule, context).passed, true);
 });
 
 test("OR object syntax works", () => {
@@ -73,9 +82,9 @@ test("OR object syntax works", () => {
 	const adminCtx = { user: { role: "admin" }, resource: { status: "pending" } };
 	const draftCtx = { user: { role: "user" }, resource: { status: "draft" } };
 	const noneCtx = { user: { role: "user" }, resource: { status: "pending" } };
-	assert.strictEqual(evaluateRule(rule, adminCtx), true);
-	assert.strictEqual(evaluateRule(rule, draftCtx), true);
-	assert.strictEqual(evaluateRule(rule, noneCtx), false);
+	assert.strictEqual(evaluateRule(rule, adminCtx).passed, true);
+	assert.strictEqual(evaluateRule(rule, draftCtx).passed, true);
+	assert.strictEqual(evaluateRule(rule, noneCtx).passed, false);
 });
 
 test("object with multiple keys is implicit AND", () => {
@@ -84,7 +93,7 @@ test("object with multiple keys is implicit AND", () => {
 		user: { role: "admin" },
 		resource: { status: "draft" },
 	};
-	assert.strictEqual(evaluateRule(rule, context), true);
+	assert.strictEqual(evaluateRule(rule, context).passed, true);
 });
 
 test("nested object expands path", () => {
@@ -102,8 +111,8 @@ test("nested object expands path", () => {
 		user: { id: "u1" },
 		invoice: { ownerId: "u2", status: "pending" },
 	};
-	assert.strictEqual(evaluateRule(rule, ctx), true);
-	assert.strictEqual(evaluateRule(rule, badCtx), false);
+	assert.strictEqual(evaluateRule(rule, ctx).passed, true);
+	assert.strictEqual(evaluateRule(rule, badCtx).passed, false);
 });
 
 // ----------------------------------------
@@ -115,7 +124,7 @@ test("NOT inside AND (should fail)", () => {
 		AND: [{ "user.role": "admin" }, { NOT: { "resource.status": "complete" } }],
 	};
 	const context = { user: { role: "admin" }, resource: { status: "complete" } };
-	assert.strictEqual(evaluateRule(rule, context), false);
+	assert.strictEqual(evaluateRule(rule, context).passed, false);
 });
 
 test("NOT inside AND (should pass)", () => {
@@ -123,7 +132,7 @@ test("NOT inside AND (should pass)", () => {
 		AND: [{ "user.role": "admin" }, { NOT: { "resource.status": "complete" } }],
 	};
 	const context = { user: { role: "admin" }, resource: { status: "pending" } };
-	assert.strictEqual(evaluateRule(rule, context), true);
+	assert.strictEqual(evaluateRule(rule, context).passed, true);
 });
 
 // ----------------------------------------
@@ -147,16 +156,16 @@ test("authorize matches correct rule", () => {
 		user: { id: "a" },
 		item: { ownerId: "a" },
 	};
-	assert.strictEqual(authorize(rules, context), true);
+	assert.strictEqual(authorize(rules, context).passed, true);
 	const createCtx = { resource: "todo", action: "create", user: { id: "a" } };
-	assert.strictEqual(authorize(rules, createCtx), true);
+	assert.strictEqual(authorize(rules, createCtx).passed, true);
 	const badCtx = {
 		resource: "todo",
 		action: "read",
 		user: { id: "b" },
 		item: { ownerId: "a" },
 	};
-	assert.strictEqual(authorize(rules, badCtx), false);
+	assert.strictEqual(authorize(rules, badCtx).passed, false);
 });
 
 test("authorize handles nested rule groups", () => {
@@ -201,7 +210,107 @@ test("authorize handles nested rule groups", () => {
 		user: { id: "b" },
 		notebook: { ownerId: "a" },
 	};
-	assert.strictEqual(authorize(rules, ctxDelete), true);
-	assert.strictEqual(authorize(rules, ctxShare), true);
-	assert.strictEqual(authorize(rules, ctxBad), false);
+	assert.strictEqual(authorize(rules, ctxDelete).passed, true);
+	assert.strictEqual(authorize(rules, ctxShare).passed, true);
+	assert.strictEqual(authorize(rules, ctxBad).passed, false);
+});
+
+// XOR logic
+test("XOR logic works via custom handler", () => {
+	const xorLogic = {
+		match: (n) => typeof n === "object" && n !== null && "XOR" in n,
+		evaluate: (n, ctx, ev) => {
+			const sub = n.XOR;
+			const arr = Array.isArray(sub)
+				? sub
+				: Object.entries(sub).map(([k, v]) => ({ [k]: v }));
+			return arr.filter((r) => ev.evaluate(r, ctx).passed).length === 1;
+		},
+	};
+	const evaluator = new DefaultEvaluator({ logic: [xorLogic] });
+	const rule = { XOR: [{ flagA: true }, { flagB: true }] };
+	const ctxA = { flagA: true };
+	const ctxB = { flagB: true };
+	const ctxBoth = { flagA: true, flagB: true };
+	const ctxNone = {};
+	assert.strictEqual(evaluator.evaluate(rule, ctxA).passed, true);
+	assert.strictEqual(evaluator.evaluate(rule, ctxB).passed, true);
+	assert.strictEqual(evaluator.evaluate(rule, ctxBoth).passed, false);
+	assert.strictEqual(evaluator.evaluate(rule, ctxNone).passed, false);
+});
+
+test("custom comparison handler works", () => {
+	const startsWith = {
+		match: (_, exp) =>
+			typeof exp === "object" && exp !== null && "startsWith" in exp,
+		evaluate: (attr, exp, ctx) => {
+			const value = attr
+				.split(".")
+				.reduce((o, k) => (o ? o[k] : undefined), ctx);
+			return typeof value === "string" && value.startsWith(exp.startsWith);
+		},
+	};
+	const evaluator = new DefaultEvaluator({ compare: [startsWith] });
+	const rule = { "user.name": { startsWith: "Jo" } };
+	assert.strictEqual(
+		evaluator.evaluate(rule, { user: { name: "John" } }).passed,
+		true,
+	);
+	assert.strictEqual(
+		evaluator.evaluate(rule, { user: { name: "Bob" } }).passed,
+		false,
+	);
+});
+
+test("custom context resolver works", () => {
+	const colonResolver = {
+		resolve: (p, ctx) =>
+			p.split(":").reduce((o, k) => (o ? o[k] : undefined), ctx),
+	};
+	const evaluator = new DefaultEvaluator({ contextResolver: colonResolver });
+	const rule = { "user:id": { reference: "resource:ownerId" } };
+	const ctx = { user: { id: "a" }, resource: { ownerId: "a" } };
+	assert.strictEqual(evaluator.evaluate(rule, ctx).passed, true);
+});
+
+test("custom rule node handler works", () => {
+	const allowIf = {
+		match: (node) =>
+			typeof node === "object" && node !== null && "allowIf" in node,
+		evaluate: (node, ctx, ev) => ev.evaluate(node.allowIf, ctx),
+	};
+	const evaluator = new DefaultEvaluator({ nodes: [allowIf] });
+	const rules = [{ allowIf: { flag: true } }];
+	assert.strictEqual(evaluator.authorize(rules, { flag: true }).passed, true);
+	assert.strictEqual(evaluator.authorize(rules, { flag: false }).passed, false);
+});
+
+test("functional rule builders compose rules", () => {
+	const builder = and(
+		field("user.id", ref("item.ownerId")),
+		not(field("item.status", "archived")),
+	);
+	const ctx = {
+		user: { id: "u1" },
+		item: { ownerId: "u1", status: "active" },
+	};
+	assert.strictEqual(evaluateRule(builder, ctx).passed, true);
+	const json = builder.toJSON();
+	const rebuilt = fromJSON(json);
+	assert.deepStrictEqual(json, rebuilt.toJSON());
+	assert.strictEqual(evaluateRule(rebuilt, ctx).passed, true);
+});
+
+test("evaluate returns detailed tree", () => {
+	const evaluator = new DefaultEvaluator();
+	const rule = {
+		AND: [{ flag: true }, { NOT: { disabled: true } }],
+	};
+	const ctx = { flag: true, disabled: false };
+	const res = evaluator.evaluate(rule, ctx);
+	assert.strictEqual(res.type, "AND");
+	assert.strictEqual(res.passed, true);
+	assert.strictEqual(res.children.length, 2);
+	assert.strictEqual(res.children[0].path, "flag");
+	assert.strictEqual(res.children[1].type, "NOT");
 });


### PR DESCRIPTION
## Summary
- default logic handlers return booleans again
- `DefaultEvaluator` builds child nodes when handlers return plain booleans
- update README example for XOR logic

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686f862566c4832e90d4f9e3b9e053ce