### PR TITLE
Add built-in XOR logic and update examples

### DIFF
--- a/accessHelper.test.js
+++ b/accessHelper.test.js
@@ -80,26 +80,26 @@ test("context performs shallow merge", () => {
 });
 
 test("custom evaluator can be provided", () => {
-	const xorLogic = {
-		match: (n) => typeof n === "object" && n !== null && "XOR" in n,
+	const nandLogic = {
+		match: (n) => typeof n === "object" && n !== null && "NAND" in n,
 		evaluate: (n, ctx, ev) => {
-			const sub = n.XOR;
+			const sub = n.NAND;
 			const arr = Array.isArray(sub)
 				? sub
 				: Object.entries(sub).map(([k, v]) => ({ [k]: v }));
-			return arr.filter((r) => ev.evaluate(r, ctx).passed).length === 1;
+			return !arr.every((r) => ev.evaluate(r, ctx).passed);
 		},
 	};
 	const evaluator = new (require("./ruleEngine").DefaultEvaluator)({
-		logic: [xorLogic],
+		logic: [nandLogic],
 	});
 	const controller = new AccessController(
-		[{ XOR: [{ a: true }, { b: true }] }],
+		[{ NAND: [{ a: true }, { b: true }] }],
 		{ evaluator },
 	);
 	assert.strictEqual(controller.check({ a: true }), true);
-	assert.strictEqual(controller.check({ b: true }), true);
 	assert.strictEqual(controller.check({ a: true, b: true }), false);
+	assert.strictEqual(controller.check({}), true);
 });
 
 test("custom context resolver via evaluator", () => {

--- a/ruleEngine.js
+++ b/ruleEngine.js
@@ -126,6 +126,25 @@ const orLogic = {
 	},
 };
 
+const xorLogic = {
+	match: (n) => typeof n === "object" && n !== null && "XOR" in n,
+	resolve(node) {
+		return Array.isArray(node.XOR)
+			? node.XOR
+			: Object.entries(node.XOR).map(([k, v]) => ({ [k]: v }));
+	},
+	evaluate(rules, ctx, ev) {
+		const children = [];
+		let passCount = 0;
+		for (const r of rules) {
+			const res = ev.evaluateRule(r, ctx);
+			children.push(res);
+			if (res.passed) passCount++;
+		}
+		return { passed: passCount === 1, children };
+	},
+};
+
 const notLogic = {
 	match: (n) => typeof n === "object" && n !== null && "NOT" in n,
 	resolve: (node) => node.NOT,
@@ -135,7 +154,7 @@ const notLogic = {
 	},
 };
 
-const defaultLogic = [arrayAndLogic, andLogic, orLogic, notLogic];
+const defaultLogic = [arrayAndLogic, andLogic, orLogic, xorLogic, notLogic];
 
 const whenRuleNode = {
 	match: (n) =>
@@ -312,6 +331,10 @@ function not(rule) {
 	return { NOT: rule };
 }
 
+function xor(...rules) {
+	return { XOR: rules };
+}
+
 module.exports = {
 	DefaultEvaluator,
 	evaluateRule: (rule, ctx, trace = []) =>
@@ -323,4 +346,5 @@ module.exports = {
 	and,
 	or,
 	not,
+	xor,
 };


### PR DESCRIPTION
## Summary
- provide built-in `XOR` logic handler and DSL helper
- document XOR in README and add NAND example for custom logic
- update functional rule builder docs
- adjust tests for the new default logic

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68750505c6c8832ea4e6611314e98222