### PR TITLE
Add express demo task API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The library processes a set of rules to determine whether a user may perform an 
 - Enforcing who may read, update or delete items in a todo application.
 - Authorising collaborative note editing or forum posts.
 - Controlling invoice workflows or other business processes.
+- Demo task management API using Express (see `packages/task-api`).
 
 Example rule sets for these scenarios are provided in the `scenarios/` folder.
 

--- a/packages/task-api/api.test.js
+++ b/packages/task-api/api.test.js
@@ -1,0 +1,93 @@
+const assert = require('node:assert');
+const { test, beforeEach, afterEach } = require('node:test');
+const http = require('node:http');
+const { app, tasks, SESSIONS } = require('./index');
+
+let server;
+let baseUrl;
+
+beforeEach(() => {
+  // reset in-memory data and start server
+  for (const k of Object.keys(tasks)) delete tasks[k];
+  server = app.listen(0);
+  const { port } = server.address();
+  baseUrl = `http://localhost:${port}`;
+});
+
+afterEach(() => {
+  server.close();
+});
+
+function request(method, path, body, token) {
+  return new Promise((resolve, reject) => {
+    const data = body ? JSON.stringify(body) : undefined;
+    const opts = new URL(path, baseUrl);
+    const req = http.request(
+      opts,
+      {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': data ? Buffer.byteLength(data) : 0,
+          'x-session': token,
+        },
+      },
+      (res) => {
+        let str = '';
+        res.on('data', (c) => (str += c));
+        res.on('end', () => {
+          resolve({ status: res.statusCode, body: str ? JSON.parse(str) : {} });
+        });
+      }
+    );
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+test('user can create and read task', async () => {
+  const create = await request(
+    'POST',
+    '/tasks',
+    { title: 'Test' },
+    'token-u1'
+  );
+  assert.strictEqual(create.status, 200);
+  const id = create.body.id;
+  const read = await request('GET', `/tasks/${id}`, null, 'token-u1');
+  assert.strictEqual(read.status, 200);
+  assert.strictEqual(read.body.title, 'Test');
+});
+
+test('collaborator can update but not delete', async () => {
+  const create = await request(
+    'POST',
+    '/tasks',
+    { title: 'A', collaborators: ['u2'] },
+    'token-u1'
+  );
+  const id = create.body.id;
+  const upd = await request(
+    'PUT',
+    `/tasks/${id}`,
+    { title: 'B' },
+    'token-u2'
+  );
+  assert.strictEqual(upd.status, 200);
+  assert.strictEqual(upd.body.title, 'B');
+  const del = await request('DELETE', `/tasks/${id}`, null, 'token-u2');
+  assert.strictEqual(del.status, 403);
+});
+
+test('owner can delete', async () => {
+  const create = await request(
+    'POST',
+    '/tasks',
+    { title: 'X' },
+    'token-u1'
+  );
+  const id = create.body.id;
+  const del = await request('DELETE', `/tasks/${id}`, null, 'token-u1');
+  assert.strictEqual(del.status, 200);
+});

--- a/packages/task-api/index.js
+++ b/packages/task-api/index.js
@@ -1,0 +1,131 @@
+const express = require('express');
+const { AccessController } = require('../../AccessController');
+
+// Demo tasks store
+const tasks = {};
+let nextId = 1;
+
+// Hardcoded sessions object (token -> user)
+const SESSIONS = {
+  'token-u1': { id: 'u1' },
+  'token-u2': { id: 'u2' },
+  'token-u3': { id: 'u3' },
+};
+
+// Authorization rules
+const rules = [
+  {
+    when: { resource: 'task' },
+    rules: [
+      {
+        when: { action: 'create' },
+        rule: { 'task.ownerId': { reference: 'user.id' } },
+      },
+      {
+        when: { action: 'read' },
+        rule: {
+          OR: [
+            { 'task.ownerId': { reference: 'user.id' } },
+            { 'user.id': { in: { reference: 'task.collaborators' } } },
+          ],
+        },
+      },
+      {
+        when: { action: 'update' },
+        rule: {
+          OR: [
+            { 'task.ownerId': { reference: 'user.id' } },
+            { 'user.id': { in: { reference: 'task.collaborators' } } },
+          ],
+        },
+      },
+      {
+        when: { action: 'delete' },
+        rule: { 'task.ownerId': { reference: 'user.id' } },
+      },
+    ],
+  },
+];
+
+const baseController = new AccessController(rules).context({ resource: 'task' });
+
+const app = express();
+app.use(express.json());
+
+// Authentication middleware setting user context
+app.use((req, res, next) => {
+  const token = req.headers['x-session'];
+  const user = token && SESSIONS[token];
+  if (!user) {
+    return res.status(401).json({ error: 'unauthenticated' });
+  }
+  req.user = user;
+  req.ac = baseController.context({ user });
+  next();
+});
+
+function check(action, task, userController) {
+  const ctrl = userController.context({ action, task });
+  return ctrl.check();
+}
+
+app.get('/tasks', (req, res) => {
+  const result = Object.values(tasks).filter((t) =>
+    check('read', t, req.ac)
+  );
+  res.json(result);
+});
+
+app.post('/tasks', (req, res) => {
+  const task = {
+    id: String(nextId++),
+    title: req.body.title,
+    ownerId: req.user.id,
+    collaborators: req.body.collaborators || [],
+  };
+  if (!check('create', task, req.ac)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  tasks[task.id] = task;
+  res.json(task);
+});
+
+app.get('/tasks/:id', (req, res) => {
+  const task = tasks[req.params.id];
+  if (!task) return res.status(404).json({ error: 'not found' });
+  if (!check('read', task, req.ac)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  res.json(task);
+});
+
+app.put('/tasks/:id', (req, res) => {
+  const task = tasks[req.params.id];
+  if (!task) return res.status(404).json({ error: 'not found' });
+  const updated = {
+    ...task,
+    title: req.body.title ?? task.title,
+    collaborators: req.body.collaborators ?? task.collaborators,
+  };
+  if (!check('update', updated, req.ac)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  tasks[req.params.id] = updated;
+  res.json(updated);
+});
+
+app.delete('/tasks/:id', (req, res) => {
+  const task = tasks[req.params.id];
+  if (!task) return res.status(404).json({ error: 'not found' });
+  if (!check('delete', task, req.ac)) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  delete tasks[req.params.id];
+  res.json({ ok: true });
+});
+
+module.exports = { app, tasks, SESSIONS };
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => console.log(`Task API listening on ${port}`));
+}

--- a/packages/task-api/package.json
+++ b/packages/task-api/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "task-api-demo",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "main": "index.js",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add example task API using Express under `packages/task-api`
- implement simple in-memory auth/session logic using this library
- include tests for main API operations
- document the new demo package in README

## Testing
- `npm run check` *(fails: npm not found)*
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d34c7c1c832e9e147817cbeef068